### PR TITLE
Qwen/Qwen2.5-7B-Instruct

### DIFF
--- a/Qwen/Qwen2.5-7B-Instruct/accuracy/client.yml
+++ b/Qwen/Qwen2.5-7B-Instruct/accuracy/client.yml
@@ -1,7 +1,3 @@
 # https://huggingface.co/Qwen/Qwen2.5-7B-Instruct
-model: "vllm"
-model_args:
-  pretrained: "Qwen/Qwen2.5-7B-Instruct"
-num_fewshot: null
-apply_chat_template: true
-fewshot_as_multiturn: true
+model: "Qwen/Qwen2.5-7B-Instruct"
+chat_template: true

--- a/Qwen/Qwen2.5-7B-Instruct/accuracy/client.yml
+++ b/Qwen/Qwen2.5-7B-Instruct/accuracy/client.yml
@@ -1,0 +1,7 @@
+# https://huggingface.co/Qwen/Qwen2.5-7B-Instruct
+model: "vllm"
+model_args:
+  pretrained: "Qwen/Qwen2.5-7B-Instruct"
+num_fewshot: null
+apply_chat_template: true
+fewshot_as_multiturn: true

--- a/Qwen/Qwen2.5-7B-Instruct/accuracy/server.yml
+++ b/Qwen/Qwen2.5-7B-Instruct/accuracy/server.yml
@@ -1,0 +1,4 @@
+# https://huggingface.co/Qwen/Qwen2.5-7B-Instruct
+model: "Qwen/Qwen2.5-7B-Instruct"
+trust_remote_code: True
+add_bos_token: False

--- a/Qwen/Qwen2.5-7B-Instruct/accuracy/tasks.yml
+++ b/Qwen/Qwen2.5-7B-Instruct/accuracy/tasks.yml
@@ -2,37 +2,37 @@ tasks:
   - name: leaderboard_math_algebra_hard
     metrics:
       - name: exact_match,none
-        value: 0.656
+        value: 0.0
 
   - name: leaderboard_math_counting_and_prob_hard
     metrics:
       - name: exact_match,none
-        value: 0.525
+        value: 0.0
 
   - name: leaderboard_math_geometry_hard
     metrics:
       - name: exact_match,none
-        value: 0.438
+        value: 0.0
 
   - name: leaderboard_math_intermediate_algebra_hard
     metrics:
       - name: exact_match,none
-        value: 0.251
+        value: 0.0
 
   - name: leaderboard_math_num_theory_hard
     metrics:
       - name: exact_match,none
-        value: 0.455
+        value: 0.0
 
   - name: leaderboard_math_prealgebra_hard
     metrics:
       - name: exact_match,none
-        value: 0.628
+        value: 0.0
 
   - name: leaderboard_math_precalculus_hard
     metrics:
       - name: exact_match,none
-        value: 0.341
+        value: 0.0
 
   - name: leaderboard_bbh_boolean_expressions
     metrics:
@@ -42,22 +42,22 @@ tasks:
   - name: leaderboard_bbh_causal_judgement
     metrics:
       - name: acc_norm,none
-        value: 0.567
+        value: 0.5294
 
   - name: leaderboard_bbh_date_understanding
     metrics:
       - name: acc_norm,none
-        value: 0.552
+        value: 0.564
 
   - name: leaderboard_bbh_disambiguation_qa
     metrics:
       - name: acc_norm,none
-        value: 0.688
+        value: 0.628
 
   - name: leaderboard_bbh_formal_fallacies
     metrics:
       - name: acc_norm,none
-        value: 0.64
+        value: 0.596
 
   - name: leaderboard_bbh_geometric_shapes
     metrics:
@@ -67,67 +67,67 @@ tasks:
   - name: leaderboard_bbh_hyperbaton
     metrics:
       - name: acc_norm,none
-        value: 0.536
+        value: 0.52
 
   - name: leaderboard_bbh_logical_deduction_five_objects
     metrics:
       - name: acc_norm,none
-        value: 0.532
+        value: 0.504
 
   - name: leaderboard_bbh_logical_deduction_seven_objects
     metrics:
       - name: acc_norm,none
-        value: 0.496
+        value: 0.472
 
   - name: leaderboard_bbh_logical_deduction_three_objects
     metrics:
       - name: acc_norm,none
-        value: 0.74
+        value: 0.76
 
   - name: leaderboard_bbh_movie_recommendation
     metrics:
       - name: acc_norm,none
-        value: 0.664
+        value: 0.568
 
   - name: leaderboard_bbh_navigate
     metrics:
       - name: acc_norm,none
-        value: 0.68
+        value: 0.692
 
   - name: leaderboard_bbh_object_counting
     metrics:
       - name: acc_norm,none
-        value: 0.404
+        value: 0.34
 
   - name: leaderboard_bbh_penguins_in_a_table
     metrics:
       - name: acc_norm,none
-        value: 0.562
+        value: 0.5616
 
   - name: leaderboard_bbh_reasoning_about_colored_objects
     metrics:
       - name: acc_norm,none
-        value: 0.624
+        value: 0.648
 
   - name: leaderboard_bbh_ruin_names
     metrics:
       - name: acc_norm,none
-        value: 0.616
+        value: 0.568
 
   - name: leaderboard_bbh_salient_translation_error_detection
     metrics:
       - name: acc_norm,none
-        value: 0.536
+        value: 0.544
 
   - name: leaderboard_bbh_snarks
     metrics:
       - name: acc_norm,none
-        value: 0.719
+        value: 0.7191
 
   - name: leaderboard_bbh_sports_understanding
     metrics:
       - name: acc_norm,none
-        value: 0.684
+        value: 0.732
 
   - name: leaderboard_bbh_temporal_sequences
     metrics:
@@ -137,60 +137,65 @@ tasks:
   - name: leaderboard_bbh_tracking_shuffled_objects_five_objects
     metrics:
       - name: acc_norm,none
-        value: 0.208
+        value: 0.16
 
   - name: leaderboard_bbh_tracking_shuffled_objects_seven_objects
     metrics:
       - name: acc_norm,none
-        value: 0.156
+        value: 0.132
 
   - name: leaderboard_bbh_tracking_shuffled_objects_three_objects
     metrics:
       - name: acc_norm,none
-        value: 0.28
+        value: 0.24
 
   - name: leaderboard_bbh_web_of_lies
     metrics:
       - name: acc_norm,none
-        value: 0.536
+        value: 0.564
 
   - name: leaderboard_gpqa_diamond
     metrics:
       - name: acc_norm,none
-        value: 0.345
+        value: 0.2929
 
   - name: leaderboard_gpqa_extended
     metrics:
       - name: acc_norm,none
-        value: 0.308
+        value: 0.2838
 
   - name: leaderboard_gpqa_main
     metrics:
       - name: acc_norm,none
-        value: 0.312
+        value: 0.2991
+
+  - name: leaderboard_mmlu_pro
+    metrics:
+      - name: acc,none
+        value: 0.4286
 
   - name: leaderboard_musr_murder_mysteries
     metrics:
       - name: acc_norm,none
-        value: 0.532
+        value: 0.512
 
   - name: leaderboard_musr_object_placements
     metrics:
       - name: acc_norm,none
-        value: 0.367
+        value: 0.246
 
   - name: leaderboard_musr_team_allocation
     metrics:
       - name: acc_norm,none
-        value: 0.388
+        value: 0.448
 
   - name: leaderboard_ifeval
     metrics:
       - name: prompt_level_strict_acc,none
-        value: 0.582
+        value: 0.7208
       - name: prompt_level_loose_acc,none
-        value: 0.647
+        value: 0.7430
       - name: inst_level_loose_acc,none
-        value: 0.748
+        value: 0.8141
       - name: inst_level_strict_acc,none
-        value: 0.693
+        value: 0.7961

--- a/Qwen/Qwen2.5-7B-Instruct/accuracy/tasks.yml
+++ b/Qwen/Qwen2.5-7B-Instruct/accuracy/tasks.yml
@@ -2,42 +2,42 @@ tasks:
   - name: leaderboard_math_algebra_hard
     metrics:
       - name: exact_match,none
-        value: 0.0
+        value: 0.7850
 
   - name: leaderboard_math_counting_and_prob_hard
     metrics:
       - name: exact_match,none
-        value: 0.0
+        value: 0.4634
 
   - name: leaderboard_math_geometry_hard
     metrics:
       - name: exact_match,none
-        value: 0.0
+        value: 0.3333
 
   - name: leaderboard_math_intermediate_algebra_hard
     metrics:
       - name: exact_match,none
-        value: 0.0
+        value: 0.2321
 
   - name: leaderboard_math_num_theory_hard
     metrics:
       - name: exact_match,none
-        value: 0.0
+        value: 0.5779
 
   - name: leaderboard_math_prealgebra_hard
     metrics:
       - name: exact_match,none
-        value: 0.0
+        value: 0.6683
 
   - name: leaderboard_math_precalculus_hard
     metrics:
       - name: exact_match,none
-        value: 0.0
+        value: 0.2740
 
   - name: leaderboard_bbh_boolean_expressions
     metrics:
       - name: acc_norm,none
-        value: 0.84
+        value: 0.844
 
   - name: leaderboard_bbh_causal_judgement
     metrics:

--- a/Qwen/Qwen2.5-7B-Instruct/accuracy/tasks.yml
+++ b/Qwen/Qwen2.5-7B-Instruct/accuracy/tasks.yml
@@ -1,128 +1,128 @@
 tasks:
+  - metrics:
+      - name: exact_match,none
+        value: 0.656
+    name: leaderboard_math_algebra_hard
+  - metrics:
+      - name: exact_match,none
+        value: 0.382
+    name: leaderboard_math_counting_and_prob_hard
+  - metrics:
+      - name: exact_match,none
+        value: 0.369
+    name: leaderboard_math_geometry_hard
+  - metrics:
+      - name: exact_match,none
+        value: 0.237
+    name: leaderboard_math_intermediate_algebra_hard
+  - metrics:
+      - name: exact_match,none
+        value: 0.339
+    name: leaderboard_math_num_theory_hard
+  - metrics:
+      - name: exact_match,none
+        value: 0.653
+    name: leaderboard_math_prealgebra_hard
+  - metrics:
+      - name: exact_match,none
+        value: 0.291
+    name: leaderboard_math_precalculus_hard
   # - metrics:
-  #     - name: exact_match,none
-  #       value: 0.656
-  #   name: leaderboard_math_algebra_hard
+  #     - name: acc_norm,none
+  #       value: 0.832
+  #   name: leaderboard_bbh_boolean_expressions
   # - metrics:
-  #     - name: exact_match,none
-  #       value: 0.382
-  #   name: leaderboard_math_counting_and_prob_hard
+  #     - name: acc_norm,none
+  #       value: 0.567
+  #   name: leaderboard_bbh_causal_judgement
   # - metrics:
-  #     - name: exact_match,none
-  #       value: 0.369
-  #   name: leaderboard_math_geometry_hard
+  #     - name: acc_norm,none
+  #       value: 0.5
+  #   name: leaderboard_bbh_date_understanding
   # - metrics:
-  #     - name: exact_match,none
-  #       value: 0.237
-  #   name: leaderboard_math_intermediate_algebra_hard
+  #     - name: acc_norm,none
+  #       value: 0.576
+  #   name: leaderboard_bbh_disambiguation_qa
   # - metrics:
-  #     - name: exact_match,none
-  #       value: 0.339
-  #   name: leaderboard_math_num_theory_hard
+  #     - name: acc_norm,none
+  #       value: 0.548
+  #   name: leaderboard_bbh_formal_fallacies
   # - metrics:
-  #     - name: exact_match,none
-  #       value: 0.653
-  #   name: leaderboard_math_prealgebra_hard
+  #     - name: acc_norm,none
+  #       value: 0.284
+  #   name: leaderboard_bbh_geometric_shapes
   # - metrics:
-  #     - name: exact_match,none
-  #       value: 0.291
-  #   name: leaderboard_math_precalculus_hard
-  - metrics:
-      - name: acc_norm,none
-        value: 0.832
-    name: leaderboard_bbh_boolean_expressions
-  - metrics:
-      - name: acc_norm,none
-        value: 0.567
-    name: leaderboard_bbh_causal_judgement
-  - metrics:
-      - name: acc_norm,none
-        value: 0.5
-    name: leaderboard_bbh_date_understanding
-  - metrics:
-      - name: acc_norm,none
-        value: 0.576
-    name: leaderboard_bbh_disambiguation_qa
-  - metrics:
-      - name: acc_norm,none
-        value: 0.548
-    name: leaderboard_bbh_formal_fallacies
-  - metrics:
-      - name: acc_norm,none
-        value: 0.284
-    name: leaderboard_bbh_geometric_shapes
-  - metrics:
-      - name: acc_norm,none
-        value: 0.66
-    name: leaderboard_bbh_hyperbaton
-  - metrics:
-      - name: acc_norm,none
-        value: 0.38
-    name: leaderboard_bbh_logical_deduction_five_objects
-  - metrics:
-      - name: acc_norm,none
-        value: 0.384
-    name: leaderboard_bbh_logical_deduction_seven_objects
-  - metrics:
-      - name: acc_norm,none
-        value: 0.62
-    name: leaderboard_bbh_logical_deduction_three_objects
-  - metrics:
-      - name: acc_norm,none
-        value: 0.516
-    name: leaderboard_bbh_movie_recommendation
-  - metrics:
-      - name: acc_norm,none
-        value: 0.596
-    name: leaderboard_bbh_navigate
-  - metrics:
-      - name: acc_norm,none
-        value: 0.328
-    name: leaderboard_bbh_object_counting
-  - metrics:
-      - name: acc_norm,none
-        value: 0.466
-    name: leaderboard_bbh_penguins_in_a_table
-  - metrics:
-      - name: acc_norm,none
-        value: 0.668
-    name: leaderboard_bbh_reasoning_about_colored_objects
-  - metrics:
-      - name: acc_norm,none
-        value: 0.624
-    name: leaderboard_bbh_ruin_names
-  - metrics:
-      - name: acc_norm,none
-        value: 0.528
-    name: leaderboard_bbh_salient_translation_error_detection
-  - metrics:
-      - name: acc_norm,none
-        value: 0.623
-    name: leaderboard_bbh_snarks
-  - metrics:
-      - name: acc_norm,none
-        value: 0.752
-    name: leaderboard_bbh_sports_understanding
-  - metrics:
-      - name: acc_norm,none
-        value: 0.444
-    name: leaderboard_bbh_temporal_sequences
-  - metrics:
-      - name: acc_norm,none
-        value: 0.244
-    name: leaderboard_bbh_tracking_shuffled_objects_five_objects
-  - metrics:
-      - name: acc_norm,none
-        value: 0.26
-    name: leaderboard_bbh_tracking_shuffled_objects_seven_objects
-  - metrics:
-      - name: acc_norm,none
-        value: 0.384
-    name: leaderboard_bbh_tracking_shuffled_objects_three_objects
-  - metrics:
-      - name: acc_norm,none
-        value: 0.472
-    name: leaderboard_bbh_web_of_lies
+  #     - name: acc_norm,none
+  #       value: 0.66
+  #   name: leaderboard_bbh_hyperbaton
+  # - metrics:
+  #     - name: acc_norm,none
+  #       value: 0.38
+  #   name: leaderboard_bbh_logical_deduction_five_objects
+  # - metrics:
+  #     - name: acc_norm,none
+  #       value: 0.384
+  #   name: leaderboard_bbh_logical_deduction_seven_objects
+  # - metrics:
+  #     - name: acc_norm,none
+  #       value: 0.62
+  #   name: leaderboard_bbh_logical_deduction_three_objects
+  # - metrics:
+  #     - name: acc_norm,none
+  #       value: 0.516
+  #   name: leaderboard_bbh_movie_recommendation
+  # - metrics:
+  #     - name: acc_norm,none
+  #       value: 0.596
+  #   name: leaderboard_bbh_navigate
+  # - metrics:
+  #     - name: acc_norm,none
+  #       value: 0.328
+  #   name: leaderboard_bbh_object_counting
+  # - metrics:
+  #     - name: acc_norm,none
+  #       value: 0.466
+  #   name: leaderboard_bbh_penguins_in_a_table
+  # - metrics:
+  #     - name: acc_norm,none
+  #       value: 0.668
+  #   name: leaderboard_bbh_reasoning_about_colored_objects
+  # - metrics:
+  #     - name: acc_norm,none
+  #       value: 0.624
+  #   name: leaderboard_bbh_ruin_names
+  # - metrics:
+  #     - name: acc_norm,none
+  #       value: 0.528
+  #   name: leaderboard_bbh_salient_translation_error_detection
+  # - metrics:
+  #     - name: acc_norm,none
+  #       value: 0.623
+  #   name: leaderboard_bbh_snarks
+  # - metrics:
+  #     - name: acc_norm,none
+  #       value: 0.752
+  #   name: leaderboard_bbh_sports_understanding
+  # - metrics:
+  #     - name: acc_norm,none
+  #       value: 0.444
+  #   name: leaderboard_bbh_temporal_sequences
+  # - metrics:
+  #     - name: acc_norm,none
+  #       value: 0.244
+  #   name: leaderboard_bbh_tracking_shuffled_objects_five_objects
+  # - metrics:
+  #     - name: acc_norm,none
+  #       value: 0.26
+  #   name: leaderboard_bbh_tracking_shuffled_objects_seven_objects
+  # - metrics:
+  #     - name: acc_norm,none
+  #       value: 0.384
+  #   name: leaderboard_bbh_tracking_shuffled_objects_three_objects
+  # - metrics:
+  #     - name: acc_norm,none
+  #       value: 0.472
+  #   name: leaderboard_bbh_web_of_lies
   # - name: leaderboard_gpqa_diamond
   #   metrics:
   #     - name: acc_norm,none
@@ -138,25 +138,28 @@ tasks:
   #     - name: acc_norm,none
   #       value: 0.312
 
-  # - metrics:
+  # - name: leaderboard_musr_murder_mysteries
+  #   metrics:
   #     - name: acc_norm,none
-  #       value: 0.56
-  #   name: leaderboard_musr_murder_mysteries
-  # - metrics:
+  #       value: 0.532
+
+  # - name: leaderboard_musr_object_placements
+  #   metrics:
   #     - name: acc_norm,none
-  #       value: 0.297
-  #   name: leaderboard_musr_object_placements
-  # - metrics:
+  #       value: 0.367
+
+  # - name: leaderboard_musr_team_allocation
+  #   metrics:
   #     - name: acc_norm,none
-  #       value: 0.304
-  #   name: leaderboard_musr_team_allocation
+  #       value: 0.388
+
   # - name: leaderboard_ifeval
   #   metrics:
   #     - name: prompt_level_strict_acc,none
-  #       value: 0.750
+  #       value: 0.582
   #     - name: prompt_level_loose_acc,none
-  #       value: 0.795
+  #       value: 0.647
   #     - name: inst_level_loose_acc,none
-  #       value: 0.855
+  #       value: 0.748
   #     - name: inst_level_strict_acc,none
-  #       value: 0.825
+  #       value: 0.693

--- a/Qwen/Qwen2.5-7B-Instruct/accuracy/tasks.yml
+++ b/Qwen/Qwen2.5-7B-Instruct/accuracy/tasks.yml
@@ -1,128 +1,159 @@
 tasks:
-  - metrics:
+  - name: leaderboard_math_algebra_hard
+    metrics:
       - name: exact_match,none
         value: 0.656
-    name: leaderboard_math_algebra_hard
-  - metrics:
+
+  - name: leaderboard_math_counting_and_prob_hard
+    metrics:
       - name: exact_match,none
-        value: 0.382
-    name: leaderboard_math_counting_and_prob_hard
-  - metrics:
+        value: 0.525
+
+  - name: leaderboard_math_geometry_hard
+    metrics:
       - name: exact_match,none
-        value: 0.369
-    name: leaderboard_math_geometry_hard
-  - metrics:
+        value: 0.438
+
+  - name: leaderboard_math_intermediate_algebra_hard
+    metrics:
       - name: exact_match,none
-        value: 0.237
-    name: leaderboard_math_intermediate_algebra_hard
-  - metrics:
+        value: 0.251
+
+  - name: leaderboard_math_num_theory_hard
+    metrics:
       - name: exact_match,none
-        value: 0.339
-    name: leaderboard_math_num_theory_hard
-  - metrics:
+        value: 0.455
+
+  - name: leaderboard_math_prealgebra_hard
+    metrics:
       - name: exact_match,none
-        value: 0.653
-    name: leaderboard_math_prealgebra_hard
-  - metrics:
+        value: 0.628
+
+  - name: leaderboard_math_precalculus_hard
+    metrics:
       - name: exact_match,none
-        value: 0.291
-    name: leaderboard_math_precalculus_hard
-  # - metrics:
-  #     - name: acc_norm,none
-  #       value: 0.832
-  #   name: leaderboard_bbh_boolean_expressions
-  # - metrics:
-  #     - name: acc_norm,none
-  #       value: 0.567
-  #   name: leaderboard_bbh_causal_judgement
-  # - metrics:
-  #     - name: acc_norm,none
-  #       value: 0.5
-  #   name: leaderboard_bbh_date_understanding
-  # - metrics:
-  #     - name: acc_norm,none
-  #       value: 0.576
-  #   name: leaderboard_bbh_disambiguation_qa
-  # - metrics:
-  #     - name: acc_norm,none
-  #       value: 0.548
-  #   name: leaderboard_bbh_formal_fallacies
-  # - metrics:
-  #     - name: acc_norm,none
-  #       value: 0.284
-  #   name: leaderboard_bbh_geometric_shapes
-  # - metrics:
-  #     - name: acc_norm,none
-  #       value: 0.66
-  #   name: leaderboard_bbh_hyperbaton
-  # - metrics:
-  #     - name: acc_norm,none
-  #       value: 0.38
-  #   name: leaderboard_bbh_logical_deduction_five_objects
-  # - metrics:
-  #     - name: acc_norm,none
-  #       value: 0.384
-  #   name: leaderboard_bbh_logical_deduction_seven_objects
-  # - metrics:
-  #     - name: acc_norm,none
-  #       value: 0.62
-  #   name: leaderboard_bbh_logical_deduction_three_objects
-  # - metrics:
-  #     - name: acc_norm,none
-  #       value: 0.516
-  #   name: leaderboard_bbh_movie_recommendation
-  # - metrics:
-  #     - name: acc_norm,none
-  #       value: 0.596
-  #   name: leaderboard_bbh_navigate
-  # - metrics:
-  #     - name: acc_norm,none
-  #       value: 0.328
-  #   name: leaderboard_bbh_object_counting
-  # - metrics:
-  #     - name: acc_norm,none
-  #       value: 0.466
-  #   name: leaderboard_bbh_penguins_in_a_table
-  # - metrics:
-  #     - name: acc_norm,none
-  #       value: 0.668
-  #   name: leaderboard_bbh_reasoning_about_colored_objects
-  # - metrics:
-  #     - name: acc_norm,none
-  #       value: 0.624
-  #   name: leaderboard_bbh_ruin_names
-  # - metrics:
-  #     - name: acc_norm,none
-  #       value: 0.528
-  #   name: leaderboard_bbh_salient_translation_error_detection
-  # - metrics:
-  #     - name: acc_norm,none
-  #       value: 0.623
-  #   name: leaderboard_bbh_snarks
-  # - metrics:
-  #     - name: acc_norm,none
-  #       value: 0.752
-  #   name: leaderboard_bbh_sports_understanding
-  # - metrics:
-  #     - name: acc_norm,none
-  #       value: 0.444
-  #   name: leaderboard_bbh_temporal_sequences
-  # - metrics:
-  #     - name: acc_norm,none
-  #       value: 0.244
-  #   name: leaderboard_bbh_tracking_shuffled_objects_five_objects
-  # - metrics:
-  #     - name: acc_norm,none
-  #       value: 0.26
-  #   name: leaderboard_bbh_tracking_shuffled_objects_seven_objects
-  # - metrics:
-  #     - name: acc_norm,none
-  #       value: 0.384
-  #   name: leaderboard_bbh_tracking_shuffled_objects_three_objects
-  # - metrics:
-  #     - name: acc_norm,none
-  #       value: 0.472
-  #   name: leaderboard_bbh_web_of_lies
+        value: 0.341
+
+  - name: leaderboard_bbh_boolean_expressions
+    metrics:
+      - name: acc_norm,none
+        value: 0.84
+
+  - name: leaderboard_bbh_causal_judgement
+    metrics:
+      - name: acc_norm,none
+        value: 0.567
+
+  - name: leaderboard_bbh_date_understanding
+    metrics:
+      - name: acc_norm,none
+        value: 0.552
+
+  - name: leaderboard_bbh_disambiguation_qa
+    metrics:
+      - name: acc_norm,none
+        value: 0.688
+
+  - name: leaderboard_bbh_formal_fallacies
+    metrics:
+      - name: acc_norm,none
+        value: 0.64
+
+  - name: leaderboard_bbh_geometric_shapes
+    metrics:
+      - name: acc_norm,none
+        value: 0.516
+
+  - name: leaderboard_bbh_hyperbaton
+    metrics:
+      - name: acc_norm,none
+        value: 0.536
+
+  - name: leaderboard_bbh_logical_deduction_five_objects
+    metrics:
+      - name: acc_norm,none
+        value: 0.532
+
+  - name: leaderboard_bbh_logical_deduction_seven_objects
+    metrics:
+      - name: acc_norm,none
+        value: 0.496
+
+  - name: leaderboard_bbh_logical_deduction_three_objects
+    metrics:
+      - name: acc_norm,none
+        value: 0.74
+
+  - name: leaderboard_bbh_movie_recommendation
+    metrics:
+      - name: acc_norm,none
+        value: 0.664
+
+  - name: leaderboard_bbh_navigate
+    metrics:
+      - name: acc_norm,none
+        value: 0.68
+
+  - name: leaderboard_bbh_object_counting
+    metrics:
+      - name: acc_norm,none
+        value: 0.404
+
+  - name: leaderboard_bbh_penguins_in_a_table
+    metrics:
+      - name: acc_norm,none
+        value: 0.562
+
+  - name: leaderboard_bbh_reasoning_about_colored_objects
+    metrics:
+      - name: acc_norm,none
+        value: 0.624
+
+  - name: leaderboard_bbh_ruin_names
+    metrics:
+      - name: acc_norm,none
+        value: 0.616
+
+  - name: leaderboard_bbh_salient_translation_error_detection
+    metrics:
+      - name: acc_norm,none
+        value: 0.536
+
+  - name: leaderboard_bbh_snarks
+    metrics:
+      - name: acc_norm,none
+        value: 0.719
+
+  - name: leaderboard_bbh_sports_understanding
+    metrics:
+      - name: acc_norm,none
+        value: 0.684
+
+  - name: leaderboard_bbh_temporal_sequences
+    metrics:
+      - name: acc_norm,none
+        value: 0.544
+
+  - name: leaderboard_bbh_tracking_shuffled_objects_five_objects
+    metrics:
+      - name: acc_norm,none
+        value: 0.208
+
+  - name: leaderboard_bbh_tracking_shuffled_objects_seven_objects
+    metrics:
+      - name: acc_norm,none
+        value: 0.156
+
+  - name: leaderboard_bbh_tracking_shuffled_objects_three_objects
+    metrics:
+      - name: acc_norm,none
+        value: 0.28
+
+  - name: leaderboard_bbh_web_of_lies
+    metrics:
+      - name: acc_norm,none
+        value: 0.536
+
   # - name: leaderboard_gpqa_diamond
   #   metrics:
   #     - name: acc_norm,none

--- a/Qwen/Qwen2.5-7B-Instruct/accuracy/tasks.yml
+++ b/Qwen/Qwen2.5-7B-Instruct/accuracy/tasks.yml
@@ -27,102 +27,102 @@ tasks:
   #     - name: exact_match,none
   #       value: 0.291
   #   name: leaderboard_math_precalculus_hard
-  # - metrics:
-  #     - name: acc_norm,none
-  #       value: 0.832
-  #   name: leaderboard_bbh_boolean_expressions
-  # - metrics:
-  #     - name: acc_norm,none
-  #       value: 0.567
-  #   name: leaderboard_bbh_causal_judgement
-  # - metrics:
-  #     - name: acc_norm,none
-  #       value: 0.5
-  #   name: leaderboard_bbh_date_understanding
-  # - metrics:
-  #     - name: acc_norm,none
-  #       value: 0.576
-  #   name: leaderboard_bbh_disambiguation_qa
-  # - metrics:
-  #     - name: acc_norm,none
-  #       value: 0.548
-  #   name: leaderboard_bbh_formal_fallacies
-  # - metrics:
-  #     - name: acc_norm,none
-  #       value: 0.284
-  #   name: leaderboard_bbh_geometric_shapes
-  # - metrics:
-  #     - name: acc_norm,none
-  #       value: 0.66
-  #   name: leaderboard_bbh_hyperbaton
-  # - metrics:
-  #     - name: acc_norm,none
-  #       value: 0.38
-  #   name: leaderboard_bbh_logical_deduction_five_objects
-  # - metrics:
-  #     - name: acc_norm,none
-  #       value: 0.384
-  #   name: leaderboard_bbh_logical_deduction_seven_objects
-  # - metrics:
-  #     - name: acc_norm,none
-  #       value: 0.62
-  #   name: leaderboard_bbh_logical_deduction_three_objects
-  # - metrics:
-  #     - name: acc_norm,none
-  #       value: 0.516
-  #   name: leaderboard_bbh_movie_recommendation
-  # - metrics:
-  #     - name: acc_norm,none
-  #       value: 0.596
-  #   name: leaderboard_bbh_navigate
-  # - metrics:
-  #     - name: acc_norm,none
-  #       value: 0.328
-  #   name: leaderboard_bbh_object_counting
-  # - metrics:
-  #     - name: acc_norm,none
-  #       value: 0.466
-  #   name: leaderboard_bbh_penguins_in_a_table
-  # - metrics:
-  #     - name: acc_norm,none
-  #       value: 0.668
-  #   name: leaderboard_bbh_reasoning_about_colored_objects
-  # - metrics:
-  #     - name: acc_norm,none
-  #       value: 0.624
-  #   name: leaderboard_bbh_ruin_names
-  # - metrics:
-  #     - name: acc_norm,none
-  #       value: 0.528
-  #   name: leaderboard_bbh_salient_translation_error_detection
-  # - metrics:
-  #     - name: acc_norm,none
-  #       value: 0.623
-  #   name: leaderboard_bbh_snarks
-  # - metrics:
-  #     - name: acc_norm,none
-  #       value: 0.752
-  #   name: leaderboard_bbh_sports_understanding
-  # - metrics:
-  #     - name: acc_norm,none
-  #       value: 0.444
-  #   name: leaderboard_bbh_temporal_sequences
-  # - metrics:
-  #     - name: acc_norm,none
-  #       value: 0.244
-  #   name: leaderboard_bbh_tracking_shuffled_objects_five_objects
-  # - metrics:
-  #     - name: acc_norm,none
-  #       value: 0.26
-  #   name: leaderboard_bbh_tracking_shuffled_objects_seven_objects
-  # - metrics:
-  #     - name: acc_norm,none
-  #       value: 0.384
-  #   name: leaderboard_bbh_tracking_shuffled_objects_three_objects
-  # - metrics:
-  #     - name: acc_norm,none
-  #       value: 0.472
-  #   name: leaderboard_bbh_web_of_lies
+  - metrics:
+      - name: acc_norm,none
+        value: 0.832
+    name: leaderboard_bbh_boolean_expressions
+  - metrics:
+      - name: acc_norm,none
+        value: 0.567
+    name: leaderboard_bbh_causal_judgement
+  - metrics:
+      - name: acc_norm,none
+        value: 0.5
+    name: leaderboard_bbh_date_understanding
+  - metrics:
+      - name: acc_norm,none
+        value: 0.576
+    name: leaderboard_bbh_disambiguation_qa
+  - metrics:
+      - name: acc_norm,none
+        value: 0.548
+    name: leaderboard_bbh_formal_fallacies
+  - metrics:
+      - name: acc_norm,none
+        value: 0.284
+    name: leaderboard_bbh_geometric_shapes
+  - metrics:
+      - name: acc_norm,none
+        value: 0.66
+    name: leaderboard_bbh_hyperbaton
+  - metrics:
+      - name: acc_norm,none
+        value: 0.38
+    name: leaderboard_bbh_logical_deduction_five_objects
+  - metrics:
+      - name: acc_norm,none
+        value: 0.384
+    name: leaderboard_bbh_logical_deduction_seven_objects
+  - metrics:
+      - name: acc_norm,none
+        value: 0.62
+    name: leaderboard_bbh_logical_deduction_three_objects
+  - metrics:
+      - name: acc_norm,none
+        value: 0.516
+    name: leaderboard_bbh_movie_recommendation
+  - metrics:
+      - name: acc_norm,none
+        value: 0.596
+    name: leaderboard_bbh_navigate
+  - metrics:
+      - name: acc_norm,none
+        value: 0.328
+    name: leaderboard_bbh_object_counting
+  - metrics:
+      - name: acc_norm,none
+        value: 0.466
+    name: leaderboard_bbh_penguins_in_a_table
+  - metrics:
+      - name: acc_norm,none
+        value: 0.668
+    name: leaderboard_bbh_reasoning_about_colored_objects
+  - metrics:
+      - name: acc_norm,none
+        value: 0.624
+    name: leaderboard_bbh_ruin_names
+  - metrics:
+      - name: acc_norm,none
+        value: 0.528
+    name: leaderboard_bbh_salient_translation_error_detection
+  - metrics:
+      - name: acc_norm,none
+        value: 0.623
+    name: leaderboard_bbh_snarks
+  - metrics:
+      - name: acc_norm,none
+        value: 0.752
+    name: leaderboard_bbh_sports_understanding
+  - metrics:
+      - name: acc_norm,none
+        value: 0.444
+    name: leaderboard_bbh_temporal_sequences
+  - metrics:
+      - name: acc_norm,none
+        value: 0.244
+    name: leaderboard_bbh_tracking_shuffled_objects_five_objects
+  - metrics:
+      - name: acc_norm,none
+        value: 0.26
+    name: leaderboard_bbh_tracking_shuffled_objects_seven_objects
+  - metrics:
+      - name: acc_norm,none
+        value: 0.384
+    name: leaderboard_bbh_tracking_shuffled_objects_three_objects
+  - metrics:
+      - name: acc_norm,none
+        value: 0.472
+    name: leaderboard_bbh_web_of_lies
   # - name: leaderboard_gpqa_diamond
   #   metrics:
   #     - name: acc_norm,none
@@ -138,18 +138,18 @@ tasks:
   #     - name: acc_norm,none
   #       value: 0.312
 
-  - metrics:
-      - name: acc_norm,none
-        value: 0.56
-    name: leaderboard_musr_murder_mysteries
-  - metrics:
-      - name: acc_norm,none
-        value: 0.297
-    name: leaderboard_musr_object_placements
-  - metrics:
-      - name: acc_norm,none
-        value: 0.304
-    name: leaderboard_musr_team_allocation
+  # - metrics:
+  #     - name: acc_norm,none
+  #       value: 0.56
+  #   name: leaderboard_musr_murder_mysteries
+  # - metrics:
+  #     - name: acc_norm,none
+  #       value: 0.297
+  #   name: leaderboard_musr_object_placements
+  # - metrics:
+  #     - name: acc_norm,none
+  #       value: 0.304
+  #   name: leaderboard_musr_team_allocation
   # - name: leaderboard_ifeval
   #   metrics:
   #     - name: prompt_level_strict_acc,none

--- a/Qwen/Qwen2.5-7B-Instruct/accuracy/tasks.yml
+++ b/Qwen/Qwen2.5-7B-Instruct/accuracy/tasks.yml
@@ -123,20 +123,20 @@ tasks:
   #     - name: acc_norm,none
   #       value: 0.472
   #   name: leaderboard_bbh_web_of_lies
-  - name: leaderboard_gpqa_diamond
-    metrics:
-      - name: acc_norm,none
-        value: 0.338
+  # - name: leaderboard_gpqa_diamond
+  #   metrics:
+  #     - name: acc_norm,none
+  #       value: 0.345
 
-  - name: leaderboard_gpqa_extended
-    metrics:
-      - name: acc_norm,none
-        value: 0.308
+  # - name: leaderboard_gpqa_extended
+  #   metrics:
+  #     - name: acc_norm,none
+  #       value: 0.308
 
-  - name: leaderboard_gpqa_main
-    metrics:
-      - name: acc_norm,none
-        value: 0.312
+  # - name: leaderboard_gpqa_main
+  #   metrics:
+  #     - name: acc_norm,none
+  #       value: 0.312
 
   # - metrics:
   #     - name: acc_norm,none
@@ -150,13 +150,13 @@ tasks:
   #     - name: acc_norm,none
   #       value: 0.304
   #   name: leaderboard_musr_team_allocation
-  # - name: leaderboard_ifeval
-  #   metrics:
-  #     - name: prompt_level_strict_acc,none
-  #       value: 0.750
-  #     - name: prompt_level_loose_acc,none
-  #       value: 0.795
-  #     - name: inst_level_loose_acc,none
-  #       value: 0.855
-  #     - name: inst_level_strict_acc,none
-  #       value: 0.825
+  - name: leaderboard_ifeval
+    metrics:
+      - name: prompt_level_strict_acc,none
+        value: 0.750
+      - name: prompt_level_loose_acc,none
+        value: 0.795
+      - name: inst_level_loose_acc,none
+        value: 0.855
+      - name: inst_level_strict_acc,none
+        value: 0.825

--- a/Qwen/Qwen2.5-7B-Instruct/accuracy/tasks.yml
+++ b/Qwen/Qwen2.5-7B-Instruct/accuracy/tasks.yml
@@ -123,18 +123,21 @@ tasks:
   #     - name: acc_norm,none
   #       value: 0.472
   #   name: leaderboard_bbh_web_of_lies
-  - metrics:
+  - name: leaderboard_gpqa_diamond
+    metrics:
       - name: acc_norm,none
-        value: 0.222
-    name: leaderboard_gpqa_diamond
-  - metrics:
+        value: 0.338
+
+  - name: leaderboard_gpqa_extended
+    metrics:
       - name: acc_norm,none
-        value: 0.295
-    name: leaderboard_gpqa_extended
-  - metrics:
+        value: 0.308
+
+  - name: leaderboard_gpqa_main
+    metrics:
       - name: acc_norm,none
-        value: 0.301
-    name: leaderboard_gpqa_main
+        value: 0.312
+
   # - metrics:
   #     - name: acc_norm,none
   #       value: 0.56

--- a/Qwen/Qwen2.5-7B-Instruct/accuracy/tasks.yml
+++ b/Qwen/Qwen2.5-7B-Instruct/accuracy/tasks.yml
@@ -154,43 +154,43 @@ tasks:
       - name: acc_norm,none
         value: 0.536
 
-  # - name: leaderboard_gpqa_diamond
-  #   metrics:
-  #     - name: acc_norm,none
-  #       value: 0.345
+  - name: leaderboard_gpqa_diamond
+    metrics:
+      - name: acc_norm,none
+        value: 0.345
 
-  # - name: leaderboard_gpqa_extended
-  #   metrics:
-  #     - name: acc_norm,none
-  #       value: 0.308
+  - name: leaderboard_gpqa_extended
+    metrics:
+      - name: acc_norm,none
+        value: 0.308
 
-  # - name: leaderboard_gpqa_main
-  #   metrics:
-  #     - name: acc_norm,none
-  #       value: 0.312
+  - name: leaderboard_gpqa_main
+    metrics:
+      - name: acc_norm,none
+        value: 0.312
 
-  # - name: leaderboard_musr_murder_mysteries
-  #   metrics:
-  #     - name: acc_norm,none
-  #       value: 0.532
+  - name: leaderboard_musr_murder_mysteries
+    metrics:
+      - name: acc_norm,none
+        value: 0.532
 
-  # - name: leaderboard_musr_object_placements
-  #   metrics:
-  #     - name: acc_norm,none
-  #       value: 0.367
+  - name: leaderboard_musr_object_placements
+    metrics:
+      - name: acc_norm,none
+        value: 0.367
 
-  # - name: leaderboard_musr_team_allocation
-  #   metrics:
-  #     - name: acc_norm,none
-  #       value: 0.388
+  - name: leaderboard_musr_team_allocation
+    metrics:
+      - name: acc_norm,none
+        value: 0.388
 
-  # - name: leaderboard_ifeval
-  #   metrics:
-  #     - name: prompt_level_strict_acc,none
-  #       value: 0.582
-  #     - name: prompt_level_loose_acc,none
-  #       value: 0.647
-  #     - name: inst_level_loose_acc,none
-  #       value: 0.748
-  #     - name: inst_level_strict_acc,none
-  #       value: 0.693
+  - name: leaderboard_ifeval
+    metrics:
+      - name: prompt_level_strict_acc,none
+        value: 0.582
+      - name: prompt_level_loose_acc,none
+        value: 0.647
+      - name: inst_level_loose_acc,none
+        value: 0.748
+      - name: inst_level_strict_acc,none
+        value: 0.693

--- a/Qwen/Qwen2.5-7B-Instruct/accuracy/tasks.yml
+++ b/Qwen/Qwen2.5-7B-Instruct/accuracy/tasks.yml
@@ -1,0 +1,159 @@
+tasks:
+  # - metrics:
+  #     - name: exact_match,none
+  #       value: 0.656
+  #   name: leaderboard_math_algebra_hard
+  # - metrics:
+  #     - name: exact_match,none
+  #       value: 0.382
+  #   name: leaderboard_math_counting_and_prob_hard
+  # - metrics:
+  #     - name: exact_match,none
+  #       value: 0.369
+  #   name: leaderboard_math_geometry_hard
+  # - metrics:
+  #     - name: exact_match,none
+  #       value: 0.237
+  #   name: leaderboard_math_intermediate_algebra_hard
+  # - metrics:
+  #     - name: exact_match,none
+  #       value: 0.339
+  #   name: leaderboard_math_num_theory_hard
+  # - metrics:
+  #     - name: exact_match,none
+  #       value: 0.653
+  #   name: leaderboard_math_prealgebra_hard
+  # - metrics:
+  #     - name: exact_match,none
+  #       value: 0.291
+  #   name: leaderboard_math_precalculus_hard
+  # - metrics:
+  #     - name: acc_norm,none
+  #       value: 0.832
+  #   name: leaderboard_bbh_boolean_expressions
+  # - metrics:
+  #     - name: acc_norm,none
+  #       value: 0.567
+  #   name: leaderboard_bbh_causal_judgement
+  # - metrics:
+  #     - name: acc_norm,none
+  #       value: 0.5
+  #   name: leaderboard_bbh_date_understanding
+  # - metrics:
+  #     - name: acc_norm,none
+  #       value: 0.576
+  #   name: leaderboard_bbh_disambiguation_qa
+  # - metrics:
+  #     - name: acc_norm,none
+  #       value: 0.548
+  #   name: leaderboard_bbh_formal_fallacies
+  # - metrics:
+  #     - name: acc_norm,none
+  #       value: 0.284
+  #   name: leaderboard_bbh_geometric_shapes
+  # - metrics:
+  #     - name: acc_norm,none
+  #       value: 0.66
+  #   name: leaderboard_bbh_hyperbaton
+  # - metrics:
+  #     - name: acc_norm,none
+  #       value: 0.38
+  #   name: leaderboard_bbh_logical_deduction_five_objects
+  # - metrics:
+  #     - name: acc_norm,none
+  #       value: 0.384
+  #   name: leaderboard_bbh_logical_deduction_seven_objects
+  # - metrics:
+  #     - name: acc_norm,none
+  #       value: 0.62
+  #   name: leaderboard_bbh_logical_deduction_three_objects
+  # - metrics:
+  #     - name: acc_norm,none
+  #       value: 0.516
+  #   name: leaderboard_bbh_movie_recommendation
+  # - metrics:
+  #     - name: acc_norm,none
+  #       value: 0.596
+  #   name: leaderboard_bbh_navigate
+  # - metrics:
+  #     - name: acc_norm,none
+  #       value: 0.328
+  #   name: leaderboard_bbh_object_counting
+  # - metrics:
+  #     - name: acc_norm,none
+  #       value: 0.466
+  #   name: leaderboard_bbh_penguins_in_a_table
+  # - metrics:
+  #     - name: acc_norm,none
+  #       value: 0.668
+  #   name: leaderboard_bbh_reasoning_about_colored_objects
+  # - metrics:
+  #     - name: acc_norm,none
+  #       value: 0.624
+  #   name: leaderboard_bbh_ruin_names
+  # - metrics:
+  #     - name: acc_norm,none
+  #       value: 0.528
+  #   name: leaderboard_bbh_salient_translation_error_detection
+  # - metrics:
+  #     - name: acc_norm,none
+  #       value: 0.623
+  #   name: leaderboard_bbh_snarks
+  # - metrics:
+  #     - name: acc_norm,none
+  #       value: 0.752
+  #   name: leaderboard_bbh_sports_understanding
+  # - metrics:
+  #     - name: acc_norm,none
+  #       value: 0.444
+  #   name: leaderboard_bbh_temporal_sequences
+  # - metrics:
+  #     - name: acc_norm,none
+  #       value: 0.244
+  #   name: leaderboard_bbh_tracking_shuffled_objects_five_objects
+  # - metrics:
+  #     - name: acc_norm,none
+  #       value: 0.26
+  #   name: leaderboard_bbh_tracking_shuffled_objects_seven_objects
+  # - metrics:
+  #     - name: acc_norm,none
+  #       value: 0.384
+  #   name: leaderboard_bbh_tracking_shuffled_objects_three_objects
+  # - metrics:
+  #     - name: acc_norm,none
+  #       value: 0.472
+  #   name: leaderboard_bbh_web_of_lies
+  - metrics:
+      - name: acc_norm,none
+        value: 0.222
+    name: leaderboard_gpqa_diamond
+  - metrics:
+      - name: acc_norm,none
+        value: 0.295
+    name: leaderboard_gpqa_extended
+  - metrics:
+      - name: acc_norm,none
+        value: 0.301
+    name: leaderboard_gpqa_main
+  # - metrics:
+  #     - name: acc_norm,none
+  #       value: 0.56
+  #   name: leaderboard_musr_murder_mysteries
+  # - metrics:
+  #     - name: acc_norm,none
+  #       value: 0.297
+  #   name: leaderboard_musr_object_placements
+  # - metrics:
+  #     - name: acc_norm,none
+  #       value: 0.304
+  #   name: leaderboard_musr_team_allocation
+  # - name: leaderboard_ifeval
+  #   metrics:
+  #     - name: prompt_level_strict_acc,none
+  #       value: 0.750
+  #     - name: prompt_level_loose_acc,none
+  #       value: 0.795
+  #     - name: inst_level_loose_acc,none
+  #       value: 0.855
+  #     - name: inst_level_strict_acc,none
+  #       value: 0.825

--- a/Qwen/Qwen2.5-7B-Instruct/accuracy/tasks.yml
+++ b/Qwen/Qwen2.5-7B-Instruct/accuracy/tasks.yml
@@ -138,25 +138,25 @@ tasks:
   #     - name: acc_norm,none
   #       value: 0.312
 
-  # - metrics:
-  #     - name: acc_norm,none
-  #       value: 0.56
-  #   name: leaderboard_musr_murder_mysteries
-  # - metrics:
-  #     - name: acc_norm,none
-  #       value: 0.297
-  #   name: leaderboard_musr_object_placements
-  # - metrics:
-  #     - name: acc_norm,none
-  #       value: 0.304
-  #   name: leaderboard_musr_team_allocation
-  - name: leaderboard_ifeval
-    metrics:
-      - name: prompt_level_strict_acc,none
-        value: 0.750
-      - name: prompt_level_loose_acc,none
-        value: 0.795
-      - name: inst_level_loose_acc,none
-        value: 0.855
-      - name: inst_level_strict_acc,none
-        value: 0.825
+  - metrics:
+      - name: acc_norm,none
+        value: 0.56
+    name: leaderboard_musr_murder_mysteries
+  - metrics:
+      - name: acc_norm,none
+        value: 0.297
+    name: leaderboard_musr_object_placements
+  - metrics:
+      - name: acc_norm,none
+        value: 0.304
+    name: leaderboard_musr_team_allocation
+  # - name: leaderboard_ifeval
+  #   metrics:
+  #     - name: prompt_level_strict_acc,none
+  #       value: 0.750
+  #     - name: prompt_level_loose_acc,none
+  #       value: 0.795
+  #     - name: inst_level_loose_acc,none
+  #       value: 0.855
+  #     - name: inst_level_strict_acc,none
+  #       value: 0.825

--- a/Qwen/Qwen2.5-7B-Instruct/storage.yml
+++ b/Qwen/Qwen2.5-7B-Instruct/storage.yml
@@ -1,0 +1,3 @@
+# https://huggingface.co/Qwen/Qwen2.5-7B-Instruct
+model: hf
+data: hf


### PR DESCRIPTION
SUMMARY:
Add accuracy model configuration for the Qwen/Qwen2.5-7B-Instruct model.

TEST PLAN:
the ground truth values are populated by running against a k8s-a100-duo instance using the nm-cicd/dmk/run-llm-eval-test branch that's currently under review.
The values need to be vetted by Research.
https://github.com/neuralmagic/nm-cicd/actions/runs/14420099469