### PR TITLE
Remove data-type arg from the guidellm config

### DIFF
--- a/meta-llama/Llama-3.1-8B-Instruct/performance/client.yml
+++ b/meta-llama/Llama-3.1-8B-Instruct/performance/client.yml
@@ -1,6 +1,5 @@
 data:
   prompt_tokens: 64
   generated_tokens: 16
-data-type: emulated
 rate-type: throughput
 max-seconds: 400


### PR DESCRIPTION
SUMMARY:
Based on recent chnages to the guidellm `data-type ` param was removed 

TEST PLAN:
guuiddelm workfloe
