### PR TITLE
add mistralai/Mistral-Small-24B-Instruct-2501 model accuracy

### DIFF
--- a/mistralai/Mistral-Small-24B-Instruct-2501/accuracy/client.yml
+++ b/mistralai/Mistral-Small-24B-Instruct-2501/accuracy/client.yml
@@ -1,0 +1,8 @@
+# llm-eval-test configs for # storage configs for https://huggingface.co/mistralai/Mistral-Small-24B-Instruct-2501
+model: "vllm"
+model_args:
+  pretrained: "mistralai/Mistral-Small-24B-Instruct-2501"
+num_fewshot:
+apply_chat_template: true
+fewshot_as_multiturn: true
+add_bos_token: false

--- a/mistralai/Mistral-Small-24B-Instruct-2501/accuracy/server.yml
+++ b/mistralai/Mistral-Small-24B-Instruct-2501/accuracy/server.yml
@@ -2,5 +2,4 @@
 model: "mistralai/Mistral-Small-24B-Instruct-2501"
 trust-remote-code: true
 enable-chunked-prefill: true
-tensor-parallel-size:
 max-model-len: 4096

--- a/mistralai/Mistral-Small-24B-Instruct-2501/accuracy/server.yml
+++ b/mistralai/Mistral-Small-24B-Instruct-2501/accuracy/server.yml
@@ -1,0 +1,6 @@
+# server configs for https://huggingface.co/mistralai/Mistral-Small-24B-Instruct-2501
+model: "mistralai/Mistral-Small-24B-Instruct-2501"
+trust-remote-code: true
+enable-chunked-prefill: true
+tensor-parallel-size:
+max-model-len: 4096

--- a/mistralai/Mistral-Small-24B-Instruct-2501/accuracy/tasks.yml
+++ b/mistralai/Mistral-Small-24B-Instruct-2501/accuracy/tasks.yml
@@ -1,188 +1,188 @@
 tasks:
-  - name: leaderboard_math_algebra_hard
-    metrics:
-      - name: exact_match,none
-        value: 0.656
+  # - name: leaderboard_math_algebra_hard
+  #   metrics:
+  #     - name: exact_match,none
+  #       value: 0.656
 
-  - name: leaderboard_math_counting_and_prob_hard
-    metrics:
-      - name: exact_match,none
-        value: 0.525
+  # - name: leaderboard_math_counting_and_prob_hard
+  #   metrics:
+  #     - name: exact_match,none
+  #       value: 0.525
 
-  - name: leaderboard_math_geometry_hard
-    metrics:
-      - name: exact_match,none
-        value: 0.438
+  # - name: leaderboard_math_geometry_hard
+  #   metrics:
+  #     - name: exact_match,none
+  #       value: 0.438
 
-  - name: leaderboard_math_intermediate_algebra_hard
-    metrics:
-      - name: exact_match,none
-        value: 0.251
+  # - name: leaderboard_math_intermediate_algebra_hard
+  #   metrics:
+  #     - name: exact_match,none
+  #       value: 0.251
 
-  - name: leaderboard_math_num_theory_hard
-    metrics:
-      - name: exact_match,none
-        value: 0.455
+  # - name: leaderboard_math_num_theory_hard
+  #   metrics:
+  #     - name: exact_match,none
+  #       value: 0.455
 
-  - name: leaderboard_math_prealgebra_hard
-    metrics:
-      - name: exact_match,none
-        value: 0.628
+  # - name: leaderboard_math_prealgebra_hard
+  #   metrics:
+  #     - name: exact_match,none
+  #       value: 0.628
 
-  - name: leaderboard_math_precalculus_hard
-    metrics:
-      - name: exact_match,none
-        value: 0.341
+  # - name: leaderboard_math_precalculus_hard
+  #   metrics:
+  #     - name: exact_match,none
+  #       value: 0.341
 
-  - name: leaderboard_bbh_boolean_expressions
-    metrics:
-      - name: acc_norm,none
-        value: 0.84
+  # - name: leaderboard_bbh_boolean_expressions
+  #   metrics:
+  #     - name: acc_norm,none
+  #       value: 0.84
 
-  - name: leaderboard_bbh_causal_judgement
-    metrics:
-      - name: acc_norm,none
-        value: 0.567
+  # - name: leaderboard_bbh_causal_judgement
+  #   metrics:
+  #     - name: acc_norm,none
+  #       value: 0.567
 
-  - name: leaderboard_bbh_date_understanding
-    metrics:
-      - name: acc_norm,none
-        value: 0.552
+  # - name: leaderboard_bbh_date_understanding
+  #   metrics:
+  #     - name: acc_norm,none
+  #       value: 0.552
 
-  - name: leaderboard_bbh_disambiguation_qa
-    metrics:
-      - name: acc_norm,none
-        value: 0.688
+  # - name: leaderboard_bbh_disambiguation_qa
+  #   metrics:
+  #     - name: acc_norm,none
+  #       value: 0.688
 
-  - name: leaderboard_bbh_formal_fallacies
-    metrics:
-      - name: acc_norm,none
-        value: 0.64
+  # - name: leaderboard_bbh_formal_fallacies
+  #   metrics:
+  #     - name: acc_norm,none
+  #       value: 0.64
 
-  - name: leaderboard_bbh_geometric_shapes
-    metrics:
-      - name: acc_norm,none
-        value: 0.516
+  # - name: leaderboard_bbh_geometric_shapes
+  #   metrics:
+  #     - name: acc_norm,none
+  #       value: 0.516
 
-  - name: leaderboard_bbh_hyperbaton
-    metrics:
-      - name: acc_norm,none
-        value: 0.536
+  # - name: leaderboard_bbh_hyperbaton
+  #   metrics:
+  #     - name: acc_norm,none
+  #       value: 0.536
 
-  - name: leaderboard_bbh_logical_deduction_five_objects
-    metrics:
-      - name: acc_norm,none
-        value: 0.532
+  # - name: leaderboard_bbh_logical_deduction_five_objects
+  #   metrics:
+  #     - name: acc_norm,none
+  #       value: 0.532
 
-  - name: leaderboard_bbh_logical_deduction_seven_objects
-    metrics:
-      - name: acc_norm,none
-        value: 0.496
+  # - name: leaderboard_bbh_logical_deduction_seven_objects
+  #   metrics:
+  #     - name: acc_norm,none
+  #       value: 0.496
 
-  - name: leaderboard_bbh_logical_deduction_three_objects
-    metrics:
-      - name: acc_norm,none
-        value: 0.74
+  # - name: leaderboard_bbh_logical_deduction_three_objects
+  #   metrics:
+  #     - name: acc_norm,none
+  #       value: 0.74
 
-  - name: leaderboard_bbh_movie_recommendation
-    metrics:
-      - name: acc_norm,none
-        value: 0.664
+  # - name: leaderboard_bbh_movie_recommendation
+  #   metrics:
+  #     - name: acc_norm,none
+  #       value: 0.664
 
-  - name: leaderboard_bbh_navigate
-    metrics:
-      - name: acc_norm,none
-        value: 0.68
+  # - name: leaderboard_bbh_navigate
+  #   metrics:
+  #     - name: acc_norm,none
+  #       value: 0.68
 
-  - name: leaderboard_bbh_object_counting
-    metrics:
-      - name: acc_norm,none
-        value: 0.404
+  # - name: leaderboard_bbh_object_counting
+  #   metrics:
+  #     - name: acc_norm,none
+  #       value: 0.404
 
-  - name: leaderboard_bbh_penguins_in_a_table
-    metrics:
-      - name: acc_norm,none
-        value: 0.562
+  # - name: leaderboard_bbh_penguins_in_a_table
+  #   metrics:
+  #     - name: acc_norm,none
+  #       value: 0.562
 
-  - name: leaderboard_bbh_reasoning_about_colored_objects
-    metrics:
-      - name: acc_norm,none
-        value: 0.624
+  # - name: leaderboard_bbh_reasoning_about_colored_objects
+  #   metrics:
+  #     - name: acc_norm,none
+  #       value: 0.624
 
-  - name: leaderboard_bbh_ruin_names
-    metrics:
-      - name: acc_norm,none
-        value: 0.616
+  # - name: leaderboard_bbh_ruin_names
+  #   metrics:
+  #     - name: acc_norm,none
+  #       value: 0.616
 
-  - name: leaderboard_bbh_salient_translation_error_detection
-    metrics:
-      - name: acc_norm,none
-        value: 0.536
+  # - name: leaderboard_bbh_salient_translation_error_detection
+  #   metrics:
+  #     - name: acc_norm,none
+  #       value: 0.536
 
-  - name: leaderboard_bbh_snarks
-    metrics:
-      - name: acc_norm,none
-        value: 0.719
+  # - name: leaderboard_bbh_snarks
+  #   metrics:
+  #     - name: acc_norm,none
+  #       value: 0.719
 
-  - name: leaderboard_bbh_sports_understanding
-    metrics:
-      - name: acc_norm,none
-        value: 0.684
+  # - name: leaderboard_bbh_sports_understanding
+  #   metrics:
+  #     - name: acc_norm,none
+  #       value: 0.684
 
-  - name: leaderboard_bbh_temporal_sequences
-    metrics:
-      - name: acc_norm,none
-        value: 0.544
+  # - name: leaderboard_bbh_temporal_sequences
+  #   metrics:
+  #     - name: acc_norm,none
+  #       value: 0.544
 
-  - name: leaderboard_bbh_tracking_shuffled_objects_five_objects
-    metrics:
-      - name: acc_norm,none
-        value: 0.208
+  # - name: leaderboard_bbh_tracking_shuffled_objects_five_objects
+  #   metrics:
+  #     - name: acc_norm,none
+  #       value: 0.208
 
-  - name: leaderboard_bbh_tracking_shuffled_objects_seven_objects
-    metrics:
-      - name: acc_norm,none
-        value: 0.156
+  # - name: leaderboard_bbh_tracking_shuffled_objects_seven_objects
+  #   metrics:
+  #     - name: acc_norm,none
+  #       value: 0.156
 
-  - name: leaderboard_bbh_tracking_shuffled_objects_three_objects
-    metrics:
-      - name: acc_norm,none
-        value: 0.28
+  # - name: leaderboard_bbh_tracking_shuffled_objects_three_objects
+  #   metrics:
+  #     - name: acc_norm,none
+  #       value: 0.28
 
-  - name: leaderboard_bbh_web_of_lies
-    metrics:
-      - name: acc_norm,none
-        value: 0.536
+  # - name: leaderboard_bbh_web_of_lies
+  #   metrics:
+  #     - name: acc_norm,none
+  #       value: 0.536
 
-  - name: leaderboard_gpqa_diamond
-    metrics:
-      - name: acc_norm,none
-        value: 0.345
+  # - name: leaderboard_gpqa_diamond
+  #   metrics:
+  #     - name: acc_norm,none
+  #       value: 0.345
 
-  - name: leaderboard_gpqa_extended
-    metrics:
-      - name: acc_norm,none
-        value: 0.308
+  # - name: leaderboard_gpqa_extended
+  #   metrics:
+  #     - name: acc_norm,none
+  #       value: 0.308
 
-  - name: leaderboard_gpqa_main
-    metrics:
-      - name: acc_norm,none
-        value: 0.312
+  # - name: leaderboard_gpqa_main
+  #   metrics:
+  #     - name: acc_norm,none
+  #       value: 0.312
 
-  - name: leaderboard_musr_murder_mysteries
-    metrics:
-      - name: acc_norm,none
-        value: 0.532
+  # - name: leaderboard_musr_murder_mysteries
+  #   metrics:
+  #     - name: acc_norm,none
+  #       value: 0.532
 
-  - name: leaderboard_musr_object_placements
-    metrics:
-      - name: acc_norm,none
-        value: 0.367
+  # - name: leaderboard_musr_object_placements
+  #   metrics:
+  #     - name: acc_norm,none
+  #       value: 0.367
 
-  - name: leaderboard_musr_team_allocation
-    metrics:
-      - name: acc_norm,none
-        value: 0.388
+  # - name: leaderboard_musr_team_allocation
+  #   metrics:
+  #     - name: acc_norm,none
+  #       value: 0.388
 
   - name: leaderboard_ifeval
     metrics:

--- a/mistralai/Mistral-Small-24B-Instruct-2501/accuracy/tasks.yml
+++ b/mistralai/Mistral-Small-24B-Instruct-2501/accuracy/tasks.yml
@@ -1,0 +1,196 @@
+tasks:
+  - name: leaderboard_math_algebra_hard
+    metrics:
+      - name: exact_match,none
+        value: 0.656
+
+  - name: leaderboard_math_counting_and_prob_hard
+    metrics:
+      - name: exact_match,none
+        value: 0.525
+
+  - name: leaderboard_math_geometry_hard
+    metrics:
+      - name: exact_match,none
+        value: 0.438
+
+  - name: leaderboard_math_intermediate_algebra_hard
+    metrics:
+      - name: exact_match,none
+        value: 0.251
+
+  - name: leaderboard_math_num_theory_hard
+    metrics:
+      - name: exact_match,none
+        value: 0.455
+
+  - name: leaderboard_math_prealgebra_hard
+    metrics:
+      - name: exact_match,none
+        value: 0.628
+
+  - name: leaderboard_math_precalculus_hard
+    metrics:
+      - name: exact_match,none
+        value: 0.341
+
+  - name: leaderboard_bbh_boolean_expressions
+    metrics:
+      - name: acc_norm,none
+        value: 0.84
+
+  - name: leaderboard_bbh_causal_judgement
+    metrics:
+      - name: acc_norm,none
+        value: 0.567
+
+  - name: leaderboard_bbh_date_understanding
+    metrics:
+      - name: acc_norm,none
+        value: 0.552
+
+  - name: leaderboard_bbh_disambiguation_qa
+    metrics:
+      - name: acc_norm,none
+        value: 0.688
+
+  - name: leaderboard_bbh_formal_fallacies
+    metrics:
+      - name: acc_norm,none
+        value: 0.64
+
+  - name: leaderboard_bbh_geometric_shapes
+    metrics:
+      - name: acc_norm,none
+        value: 0.516
+
+  - name: leaderboard_bbh_hyperbaton
+    metrics:
+      - name: acc_norm,none
+        value: 0.536
+
+  - name: leaderboard_bbh_logical_deduction_five_objects
+    metrics:
+      - name: acc_norm,none
+        value: 0.532
+
+  - name: leaderboard_bbh_logical_deduction_seven_objects
+    metrics:
+      - name: acc_norm,none
+        value: 0.496
+
+  - name: leaderboard_bbh_logical_deduction_three_objects
+    metrics:
+      - name: acc_norm,none
+        value: 0.74
+
+  - name: leaderboard_bbh_movie_recommendation
+    metrics:
+      - name: acc_norm,none
+        value: 0.664
+
+  - name: leaderboard_bbh_navigate
+    metrics:
+      - name: acc_norm,none
+        value: 0.68
+
+  - name: leaderboard_bbh_object_counting
+    metrics:
+      - name: acc_norm,none
+        value: 0.404
+
+  - name: leaderboard_bbh_penguins_in_a_table
+    metrics:
+      - name: acc_norm,none
+        value: 0.562
+
+  - name: leaderboard_bbh_reasoning_about_colored_objects
+    metrics:
+      - name: acc_norm,none
+        value: 0.624
+
+  - name: leaderboard_bbh_ruin_names
+    metrics:
+      - name: acc_norm,none
+        value: 0.616
+
+  - name: leaderboard_bbh_salient_translation_error_detection
+    metrics:
+      - name: acc_norm,none
+        value: 0.536
+
+  - name: leaderboard_bbh_snarks
+    metrics:
+      - name: acc_norm,none
+        value: 0.719
+
+  - name: leaderboard_bbh_sports_understanding
+    metrics:
+      - name: acc_norm,none
+        value: 0.684
+
+  - name: leaderboard_bbh_temporal_sequences
+    metrics:
+      - name: acc_norm,none
+        value: 0.544
+
+  - name: leaderboard_bbh_tracking_shuffled_objects_five_objects
+    metrics:
+      - name: acc_norm,none
+        value: 0.208
+
+  - name: leaderboard_bbh_tracking_shuffled_objects_seven_objects
+    metrics:
+      - name: acc_norm,none
+        value: 0.156
+
+  - name: leaderboard_bbh_tracking_shuffled_objects_three_objects
+    metrics:
+      - name: acc_norm,none
+        value: 0.28
+
+  - name: leaderboard_bbh_web_of_lies
+    metrics:
+      - name: acc_norm,none
+        value: 0.536
+
+  - name: leaderboard_gpqa_diamond
+    metrics:
+      - name: acc_norm,none
+        value: 0.345
+
+  - name: leaderboard_gpqa_extended
+    metrics:
+      - name: acc_norm,none
+        value: 0.308
+
+  - name: leaderboard_gpqa_main
+    metrics:
+      - name: acc_norm,none
+        value: 0.312
+
+  - name: leaderboard_musr_murder_mysteries
+    metrics:
+      - name: acc_norm,none
+        value: 0.532
+
+  - name: leaderboard_musr_object_placements
+    metrics:
+      - name: acc_norm,none
+        value: 0.367
+
+  - name: leaderboard_musr_team_allocation
+    metrics:
+      - name: acc_norm,none
+        value: 0.388
+
+  - name: leaderboard_ifeval
+    metrics:
+      - name: prompt_level_strict_acc,none
+        value: 0.582
+      - name: prompt_level_loose_acc,none
+        value: 0.647
+      - name: inst_level_loose_acc,none
+        value: 0.748
+      - name: inst_level_strict_acc,none
+        value: 0.693

--- a/mistralai/Mistral-Small-24B-Instruct-2501/accuracy/tasks.yml
+++ b/mistralai/Mistral-Small-24B-Instruct-2501/accuracy/tasks.yml
@@ -12,7 +12,7 @@ tasks:
   - name: leaderboard_math_geometry_hard
     metrics:
       - name: exact_match,none
-        value: 0.359
+        value: 0.366
 
   - name: leaderboard_math_intermediate_algebra_hard
     metrics:

--- a/mistralai/Mistral-Small-24B-Instruct-2501/accuracy/tasks.yml
+++ b/mistralai/Mistral-Small-24B-Instruct-2501/accuracy/tasks.yml
@@ -1,196 +1,196 @@
 tasks:
-  # - name: leaderboard_math_algebra_hard
-  #   metrics:
-  #     - name: exact_match,none
-  #       value: 0.656
+  - name: leaderboard_math_algebra_hard
+    metrics:
+      - name: exact_match,none
+        value: 0.703
 
-  # - name: leaderboard_math_counting_and_prob_hard
-  #   metrics:
-  #     - name: exact_match,none
-  #       value: 0.525
+  - name: leaderboard_math_counting_and_prob_hard
+    metrics:
+      - name: exact_match,none
+        value: 0.489
 
-  # - name: leaderboard_math_geometry_hard
-  #   metrics:
-  #     - name: exact_match,none
-  #       value: 0.438
+  - name: leaderboard_math_geometry_hard
+    metrics:
+      - name: exact_match,none
+        value: 0.359
 
-  # - name: leaderboard_math_intermediate_algebra_hard
-  #   metrics:
-  #     - name: exact_match,none
-  #       value: 0.251
+  - name: leaderboard_math_intermediate_algebra_hard
+    metrics:
+      - name: exact_match,none
+        value: 0.283
 
-  # - name: leaderboard_math_num_theory_hard
-  #   metrics:
-  #     - name: exact_match,none
-  #       value: 0.455
+  - name: leaderboard_math_num_theory_hard
+    metrics:
+      - name: exact_match,none
+        value: 0.476
 
-  # - name: leaderboard_math_prealgebra_hard
-  #   metrics:
-  #     - name: exact_match,none
-  #       value: 0.628
+  - name: leaderboard_math_prealgebra_hard
+    metrics:
+      - name: exact_match,none
+        value: 0.695
 
-  # - name: leaderboard_math_precalculus_hard
-  #   metrics:
-  #     - name: exact_match,none
-  #       value: 0.341
+  - name: leaderboard_math_precalculus_hard
+    metrics:
+      - name: exact_match,none
+        value: 0.355
 
   - name: leaderboard_bbh_boolean_expressions
     metrics:
       - name: acc_norm,none
-        value: 0.84
+        value: 0.876
 
   - name: leaderboard_bbh_causal_judgement
     metrics:
       - name: acc_norm,none
-        value: 0.567
+        value: 0.652
 
   - name: leaderboard_bbh_date_understanding
     metrics:
       - name: acc_norm,none
-        value: 0.552
+        value: 0.796
 
   - name: leaderboard_bbh_disambiguation_qa
     metrics:
       - name: acc_norm,none
-        value: 0.688
+        value: 0.696
 
   - name: leaderboard_bbh_formal_fallacies
     metrics:
       - name: acc_norm,none
-        value: 0.64
+        value: 0.684
 
   - name: leaderboard_bbh_geometric_shapes
     metrics:
       - name: acc_norm,none
-        value: 0.516
+        value: 0.508
 
   - name: leaderboard_bbh_hyperbaton
     metrics:
       - name: acc_norm,none
-        value: 0.536
+        value: 0.78
 
   - name: leaderboard_bbh_logical_deduction_five_objects
     metrics:
       - name: acc_norm,none
-        value: 0.532
+        value: 0.632
 
   - name: leaderboard_bbh_logical_deduction_seven_objects
     metrics:
       - name: acc_norm,none
-        value: 0.496
+        value: 0.636
 
   - name: leaderboard_bbh_logical_deduction_three_objects
     metrics:
       - name: acc_norm,none
-        value: 0.74
+        value: 0.876
 
   - name: leaderboard_bbh_movie_recommendation
     metrics:
       - name: acc_norm,none
-        value: 0.664
+        value: 0.848
 
   - name: leaderboard_bbh_navigate
     metrics:
       - name: acc_norm,none
-        value: 0.68
+        value: 0.688
 
   - name: leaderboard_bbh_object_counting
     metrics:
       - name: acc_norm,none
-        value: 0.404
+        value: 0.42
 
   - name: leaderboard_bbh_penguins_in_a_table
     metrics:
       - name: acc_norm,none
-        value: 0.562
+        value: 0.767
 
   - name: leaderboard_bbh_reasoning_about_colored_objects
     metrics:
       - name: acc_norm,none
-        value: 0.624
+        value: 0.764
 
   - name: leaderboard_bbh_ruin_names
     metrics:
       - name: acc_norm,none
-        value: 0.616
+        value: 0.868
 
   - name: leaderboard_bbh_salient_translation_error_detection
     metrics:
       - name: acc_norm,none
-        value: 0.536
+        value: 0.684
 
   - name: leaderboard_bbh_snarks
     metrics:
       - name: acc_norm,none
-        value: 0.719
+        value: 0.725
 
   - name: leaderboard_bbh_sports_understanding
     metrics:
       - name: acc_norm,none
-        value: 0.684
+        value: 0.836
 
   - name: leaderboard_bbh_temporal_sequences
     metrics:
       - name: acc_norm,none
-        value: 0.544
+        value: 0.984
 
   - name: leaderboard_bbh_tracking_shuffled_objects_five_objects
     metrics:
       - name: acc_norm,none
-        value: 0.208
+        value: 0.288
 
   - name: leaderboard_bbh_tracking_shuffled_objects_seven_objects
     metrics:
       - name: acc_norm,none
-        value: 0.156
+        value: 0.224
 
   - name: leaderboard_bbh_tracking_shuffled_objects_three_objects
     metrics:
       - name: acc_norm,none
-        value: 0.28
+        value: 0.348
 
   - name: leaderboard_bbh_web_of_lies
     metrics:
       - name: acc_norm,none
-        value: 0.536
+        value: 0.52
 
-  # - name: leaderboard_gpqa_diamond
-  #   metrics:
-  #     - name: acc_norm,none
-  #       value: 0.399
+  - name: leaderboard_gpqa_diamond
+    metrics:
+      - name: acc_norm,none
+        value: 0.399
 
-  # - name: leaderboard_gpqa_extended
-  #   metrics:
-  #     - name: acc_norm,none
-  #       value: 0.405
+  - name: leaderboard_gpqa_extended
+    metrics:
+      - name: acc_norm,none
+        value: 0.405
 
-  # - name: leaderboard_gpqa_main
-  #   metrics:
-  #     - name: acc_norm,none
-  #       value: 0.393
+  - name: leaderboard_gpqa_main
+    metrics:
+      - name: acc_norm,none
+        value: 0.393
 
-  # - name: leaderboard_musr_murder_mysteries
-  #   metrics:
-  #     - name: acc_norm,none
-  #       value: 0.556
+  - name: leaderboard_musr_murder_mysteries
+    metrics:
+      - name: acc_norm,none
+        value: 0.556
 
-  # - name: leaderboard_musr_object_placements
-  #   metrics:
-  #     - name: acc_norm,none
-  #       value: 0.437
+  - name: leaderboard_musr_object_placements
+    metrics:
+      - name: acc_norm,none
+        value: 0.437
 
-  # - name: leaderboard_musr_team_allocation
-  #   metrics:
-  #     - name: acc_norm,none
-  #       value: 0.404
+  - name: leaderboard_musr_team_allocation
+    metrics:
+      - name: acc_norm,none
+        value: 0.404
 
-  # - name: leaderboard_ifeval
-  #   metrics:
-  #     - name: prompt_level_strict_acc,none
-  #       value: 0.582
-  #     - name: prompt_level_loose_acc,none
-  #       value: 0.647
-  #     - name: inst_level_loose_acc,none
-  #       value: 0.748
-  #     - name: inst_level_strict_acc,none
-  #       value: 0.693
+  - name: leaderboard_ifeval
+    metrics:
+      - name: prompt_level_strict_acc,none
+        value: 0.582
+      - name: prompt_level_loose_acc,none
+        value: 0.647
+      - name: inst_level_loose_acc,none
+        value: 0.748
+      - name: inst_level_strict_acc,none
+        value: 0.693

--- a/mistralai/Mistral-Small-24B-Instruct-2501/accuracy/tasks.yml
+++ b/mistralai/Mistral-Small-24B-Instruct-2501/accuracy/tasks.yml
@@ -154,35 +154,35 @@ tasks:
   #     - name: acc_norm,none
   #       value: 0.536
 
-  # - name: leaderboard_gpqa_diamond
-  #   metrics:
-  #     - name: acc_norm,none
-  #       value: 0.345
-
-  # - name: leaderboard_gpqa_extended
-  #   metrics:
-  #     - name: acc_norm,none
-  #       value: 0.308
-
-  # - name: leaderboard_gpqa_main
-  #   metrics:
-  #     - name: acc_norm,none
-  #       value: 0.312
-
-  - name: leaderboard_musr_murder_mysteries
+  - name: leaderboard_gpqa_diamond
     metrics:
       - name: acc_norm,none
-        value: 0.532
+        value: 0.345
 
-  - name: leaderboard_musr_object_placements
+  - name: leaderboard_gpqa_extended
     metrics:
       - name: acc_norm,none
-        value: 0.367
+        value: 0.308
 
-  - name: leaderboard_musr_team_allocation
+  - name: leaderboard_gpqa_main
     metrics:
       - name: acc_norm,none
-        value: 0.388
+        value: 0.312
+
+  # - name: leaderboard_musr_murder_mysteries
+  #   metrics:
+  #     - name: acc_norm,none
+  #       value: 0.532
+
+  # - name: leaderboard_musr_object_placements
+  #   metrics:
+  #     - name: acc_norm,none
+  #       value: 0.367
+
+  # - name: leaderboard_musr_team_allocation
+  #   metrics:
+  #     - name: acc_norm,none
+  #       value: 0.388
 
   # - name: leaderboard_ifeval
   #   metrics:

--- a/mistralai/Mistral-Small-24B-Instruct-2501/accuracy/tasks.yml
+++ b/mistralai/Mistral-Small-24B-Instruct-2501/accuracy/tasks.yml
@@ -154,43 +154,43 @@ tasks:
   #     - name: acc_norm,none
   #       value: 0.536
 
-  - name: leaderboard_gpqa_diamond
-    metrics:
-      - name: acc_norm,none
-        value: 0.345
+  # - name: leaderboard_gpqa_diamond
+  #   metrics:
+  #     - name: acc_norm,none
+  #       value: 0.399
 
-  - name: leaderboard_gpqa_extended
-    metrics:
-      - name: acc_norm,none
-        value: 0.308
+  # - name: leaderboard_gpqa_extended
+  #   metrics:
+  #     - name: acc_norm,none
+  #       value: 0.405
 
-  - name: leaderboard_gpqa_main
-    metrics:
-      - name: acc_norm,none
-        value: 0.312
+  # - name: leaderboard_gpqa_main
+  #   metrics:
+  #     - name: acc_norm,none
+  #       value: 0.393
 
   # - name: leaderboard_musr_murder_mysteries
   #   metrics:
   #     - name: acc_norm,none
-  #       value: 0.532
+  #       value: 0.556
 
   # - name: leaderboard_musr_object_placements
   #   metrics:
   #     - name: acc_norm,none
-  #       value: 0.367
+  #       value: 0.437
 
   # - name: leaderboard_musr_team_allocation
   #   metrics:
   #     - name: acc_norm,none
-  #       value: 0.388
+  #       value: 0.404
 
-  # - name: leaderboard_ifeval
-  #   metrics:
-  #     - name: prompt_level_strict_acc,none
-  #       value: 0.582
-  #     - name: prompt_level_loose_acc,none
-  #       value: 0.647
-  #     - name: inst_level_loose_acc,none
-  #       value: 0.748
-  #     - name: inst_level_strict_acc,none
-  #       value: 0.693
+  - name: leaderboard_ifeval
+    metrics:
+      - name: prompt_level_strict_acc,none
+        value: 0.582
+      - name: prompt_level_loose_acc,none
+        value: 0.647
+      - name: inst_level_loose_acc,none
+        value: 0.748
+      - name: inst_level_strict_acc,none
+        value: 0.693

--- a/mistralai/Mistral-Small-24B-Instruct-2501/accuracy/tasks.yml
+++ b/mistralai/Mistral-Small-24B-Instruct-2501/accuracy/tasks.yml
@@ -1,38 +1,38 @@
 tasks:
-  # - name: leaderboard_math_algebra_hard
-  #   metrics:
-  #     - name: exact_match,none
-  #       value: 0.656
+  - name: leaderboard_math_algebra_hard
+    metrics:
+      - name: exact_match,none
+        value: 0.656
 
-  # - name: leaderboard_math_counting_and_prob_hard
-  #   metrics:
-  #     - name: exact_match,none
-  #       value: 0.525
+  - name: leaderboard_math_counting_and_prob_hard
+    metrics:
+      - name: exact_match,none
+        value: 0.525
 
-  # - name: leaderboard_math_geometry_hard
-  #   metrics:
-  #     - name: exact_match,none
-  #       value: 0.438
+  - name: leaderboard_math_geometry_hard
+    metrics:
+      - name: exact_match,none
+        value: 0.438
 
-  # - name: leaderboard_math_intermediate_algebra_hard
-  #   metrics:
-  #     - name: exact_match,none
-  #       value: 0.251
+  - name: leaderboard_math_intermediate_algebra_hard
+    metrics:
+      - name: exact_match,none
+        value: 0.251
 
-  # - name: leaderboard_math_num_theory_hard
-  #   metrics:
-  #     - name: exact_match,none
-  #       value: 0.455
+  - name: leaderboard_math_num_theory_hard
+    metrics:
+      - name: exact_match,none
+        value: 0.455
 
-  # - name: leaderboard_math_prealgebra_hard
-  #   metrics:
-  #     - name: exact_match,none
-  #       value: 0.628
+  - name: leaderboard_math_prealgebra_hard
+    metrics:
+      - name: exact_match,none
+        value: 0.628
 
-  # - name: leaderboard_math_precalculus_hard
-  #   metrics:
-  #     - name: exact_match,none
-  #       value: 0.341
+  - name: leaderboard_math_precalculus_hard
+    metrics:
+      - name: exact_match,none
+        value: 0.341
 
   # - name: leaderboard_bbh_boolean_expressions
   #   metrics:
@@ -184,13 +184,13 @@ tasks:
   #     - name: acc_norm,none
   #       value: 0.404
 
-  - name: leaderboard_ifeval
-    metrics:
-      - name: prompt_level_strict_acc,none
-        value: 0.582
-      - name: prompt_level_loose_acc,none
-        value: 0.647
-      - name: inst_level_loose_acc,none
-        value: 0.748
-      - name: inst_level_strict_acc,none
-        value: 0.693
+  # - name: leaderboard_ifeval
+  #   metrics:
+  #     - name: prompt_level_strict_acc,none
+  #       value: 0.582
+  #     - name: prompt_level_loose_acc,none
+  #       value: 0.647
+  #     - name: inst_level_loose_acc,none
+  #       value: 0.748
+  #     - name: inst_level_strict_acc,none
+  #       value: 0.693

--- a/mistralai/Mistral-Small-24B-Instruct-2501/accuracy/tasks.yml
+++ b/mistralai/Mistral-Small-24B-Instruct-2501/accuracy/tasks.yml
@@ -1,3 +1,4 @@
+# collected vllm v0.8.3.post1 on k8s-a100-duo
 tasks:
   - name: leaderboard_math_algebra_hard
     metrics:

--- a/mistralai/Mistral-Small-24B-Instruct-2501/accuracy/tasks.yml
+++ b/mistralai/Mistral-Small-24B-Instruct-2501/accuracy/tasks.yml
@@ -169,28 +169,28 @@ tasks:
   #     - name: acc_norm,none
   #       value: 0.312
 
-  # - name: leaderboard_musr_murder_mysteries
-  #   metrics:
-  #     - name: acc_norm,none
-  #       value: 0.532
-
-  # - name: leaderboard_musr_object_placements
-  #   metrics:
-  #     - name: acc_norm,none
-  #       value: 0.367
-
-  # - name: leaderboard_musr_team_allocation
-  #   metrics:
-  #     - name: acc_norm,none
-  #       value: 0.388
-
-  - name: leaderboard_ifeval
+  - name: leaderboard_musr_murder_mysteries
     metrics:
-      - name: prompt_level_strict_acc,none
-        value: 0.582
-      - name: prompt_level_loose_acc,none
-        value: 0.647
-      - name: inst_level_loose_acc,none
-        value: 0.748
-      - name: inst_level_strict_acc,none
-        value: 0.693
+      - name: acc_norm,none
+        value: 0.532
+
+  - name: leaderboard_musr_object_placements
+    metrics:
+      - name: acc_norm,none
+        value: 0.367
+
+  - name: leaderboard_musr_team_allocation
+    metrics:
+      - name: acc_norm,none
+        value: 0.388
+
+  # - name: leaderboard_ifeval
+  #   metrics:
+  #     - name: prompt_level_strict_acc,none
+  #       value: 0.582
+  #     - name: prompt_level_loose_acc,none
+  #       value: 0.647
+  #     - name: inst_level_loose_acc,none
+  #       value: 0.748
+  #     - name: inst_level_strict_acc,none
+  #       value: 0.693

--- a/mistralai/Mistral-Small-24B-Instruct-2501/accuracy/tasks.yml
+++ b/mistralai/Mistral-Small-24B-Instruct-2501/accuracy/tasks.yml
@@ -1,158 +1,158 @@
 tasks:
-  - name: leaderboard_math_algebra_hard
+  # - name: leaderboard_math_algebra_hard
+  #   metrics:
+  #     - name: exact_match,none
+  #       value: 0.656
+
+  # - name: leaderboard_math_counting_and_prob_hard
+  #   metrics:
+  #     - name: exact_match,none
+  #       value: 0.525
+
+  # - name: leaderboard_math_geometry_hard
+  #   metrics:
+  #     - name: exact_match,none
+  #       value: 0.438
+
+  # - name: leaderboard_math_intermediate_algebra_hard
+  #   metrics:
+  #     - name: exact_match,none
+  #       value: 0.251
+
+  # - name: leaderboard_math_num_theory_hard
+  #   metrics:
+  #     - name: exact_match,none
+  #       value: 0.455
+
+  # - name: leaderboard_math_prealgebra_hard
+  #   metrics:
+  #     - name: exact_match,none
+  #       value: 0.628
+
+  # - name: leaderboard_math_precalculus_hard
+  #   metrics:
+  #     - name: exact_match,none
+  #       value: 0.341
+
+  - name: leaderboard_bbh_boolean_expressions
     metrics:
-      - name: exact_match,none
-        value: 0.656
+      - name: acc_norm,none
+        value: 0.84
 
-  - name: leaderboard_math_counting_and_prob_hard
+  - name: leaderboard_bbh_causal_judgement
     metrics:
-      - name: exact_match,none
-        value: 0.525
+      - name: acc_norm,none
+        value: 0.567
 
-  - name: leaderboard_math_geometry_hard
+  - name: leaderboard_bbh_date_understanding
     metrics:
-      - name: exact_match,none
-        value: 0.438
+      - name: acc_norm,none
+        value: 0.552
 
-  - name: leaderboard_math_intermediate_algebra_hard
+  - name: leaderboard_bbh_disambiguation_qa
     metrics:
-      - name: exact_match,none
-        value: 0.251
+      - name: acc_norm,none
+        value: 0.688
 
-  - name: leaderboard_math_num_theory_hard
+  - name: leaderboard_bbh_formal_fallacies
     metrics:
-      - name: exact_match,none
-        value: 0.455
+      - name: acc_norm,none
+        value: 0.64
 
-  - name: leaderboard_math_prealgebra_hard
+  - name: leaderboard_bbh_geometric_shapes
     metrics:
-      - name: exact_match,none
-        value: 0.628
+      - name: acc_norm,none
+        value: 0.516
 
-  - name: leaderboard_math_precalculus_hard
+  - name: leaderboard_bbh_hyperbaton
     metrics:
-      - name: exact_match,none
-        value: 0.341
+      - name: acc_norm,none
+        value: 0.536
 
-  # - name: leaderboard_bbh_boolean_expressions
-  #   metrics:
-  #     - name: acc_norm,none
-  #       value: 0.84
+  - name: leaderboard_bbh_logical_deduction_five_objects
+    metrics:
+      - name: acc_norm,none
+        value: 0.532
 
-  # - name: leaderboard_bbh_causal_judgement
-  #   metrics:
-  #     - name: acc_norm,none
-  #       value: 0.567
+  - name: leaderboard_bbh_logical_deduction_seven_objects
+    metrics:
+      - name: acc_norm,none
+        value: 0.496
 
-  # - name: leaderboard_bbh_date_understanding
-  #   metrics:
-  #     - name: acc_norm,none
-  #       value: 0.552
+  - name: leaderboard_bbh_logical_deduction_three_objects
+    metrics:
+      - name: acc_norm,none
+        value: 0.74
 
-  # - name: leaderboard_bbh_disambiguation_qa
-  #   metrics:
-  #     - name: acc_norm,none
-  #       value: 0.688
+  - name: leaderboard_bbh_movie_recommendation
+    metrics:
+      - name: acc_norm,none
+        value: 0.664
 
-  # - name: leaderboard_bbh_formal_fallacies
-  #   metrics:
-  #     - name: acc_norm,none
-  #       value: 0.64
+  - name: leaderboard_bbh_navigate
+    metrics:
+      - name: acc_norm,none
+        value: 0.68
 
-  # - name: leaderboard_bbh_geometric_shapes
-  #   metrics:
-  #     - name: acc_norm,none
-  #       value: 0.516
+  - name: leaderboard_bbh_object_counting
+    metrics:
+      - name: acc_norm,none
+        value: 0.404
 
-  # - name: leaderboard_bbh_hyperbaton
-  #   metrics:
-  #     - name: acc_norm,none
-  #       value: 0.536
+  - name: leaderboard_bbh_penguins_in_a_table
+    metrics:
+      - name: acc_norm,none
+        value: 0.562
 
-  # - name: leaderboard_bbh_logical_deduction_five_objects
-  #   metrics:
-  #     - name: acc_norm,none
-  #       value: 0.532
+  - name: leaderboard_bbh_reasoning_about_colored_objects
+    metrics:
+      - name: acc_norm,none
+        value: 0.624
 
-  # - name: leaderboard_bbh_logical_deduction_seven_objects
-  #   metrics:
-  #     - name: acc_norm,none
-  #       value: 0.496
+  - name: leaderboard_bbh_ruin_names
+    metrics:
+      - name: acc_norm,none
+        value: 0.616
 
-  # - name: leaderboard_bbh_logical_deduction_three_objects
-  #   metrics:
-  #     - name: acc_norm,none
-  #       value: 0.74
+  - name: leaderboard_bbh_salient_translation_error_detection
+    metrics:
+      - name: acc_norm,none
+        value: 0.536
 
-  # - name: leaderboard_bbh_movie_recommendation
-  #   metrics:
-  #     - name: acc_norm,none
-  #       value: 0.664
+  - name: leaderboard_bbh_snarks
+    metrics:
+      - name: acc_norm,none
+        value: 0.719
 
-  # - name: leaderboard_bbh_navigate
-  #   metrics:
-  #     - name: acc_norm,none
-  #       value: 0.68
+  - name: leaderboard_bbh_sports_understanding
+    metrics:
+      - name: acc_norm,none
+        value: 0.684
 
-  # - name: leaderboard_bbh_object_counting
-  #   metrics:
-  #     - name: acc_norm,none
-  #       value: 0.404
+  - name: leaderboard_bbh_temporal_sequences
+    metrics:
+      - name: acc_norm,none
+        value: 0.544
 
-  # - name: leaderboard_bbh_penguins_in_a_table
-  #   metrics:
-  #     - name: acc_norm,none
-  #       value: 0.562
+  - name: leaderboard_bbh_tracking_shuffled_objects_five_objects
+    metrics:
+      - name: acc_norm,none
+        value: 0.208
 
-  # - name: leaderboard_bbh_reasoning_about_colored_objects
-  #   metrics:
-  #     - name: acc_norm,none
-  #       value: 0.624
+  - name: leaderboard_bbh_tracking_shuffled_objects_seven_objects
+    metrics:
+      - name: acc_norm,none
+        value: 0.156
 
-  # - name: leaderboard_bbh_ruin_names
-  #   metrics:
-  #     - name: acc_norm,none
-  #       value: 0.616
+  - name: leaderboard_bbh_tracking_shuffled_objects_three_objects
+    metrics:
+      - name: acc_norm,none
+        value: 0.28
 
-  # - name: leaderboard_bbh_salient_translation_error_detection
-  #   metrics:
-  #     - name: acc_norm,none
-  #       value: 0.536
-
-  # - name: leaderboard_bbh_snarks
-  #   metrics:
-  #     - name: acc_norm,none
-  #       value: 0.719
-
-  # - name: leaderboard_bbh_sports_understanding
-  #   metrics:
-  #     - name: acc_norm,none
-  #       value: 0.684
-
-  # - name: leaderboard_bbh_temporal_sequences
-  #   metrics:
-  #     - name: acc_norm,none
-  #       value: 0.544
-
-  # - name: leaderboard_bbh_tracking_shuffled_objects_five_objects
-  #   metrics:
-  #     - name: acc_norm,none
-  #       value: 0.208
-
-  # - name: leaderboard_bbh_tracking_shuffled_objects_seven_objects
-  #   metrics:
-  #     - name: acc_norm,none
-  #       value: 0.156
-
-  # - name: leaderboard_bbh_tracking_shuffled_objects_three_objects
-  #   metrics:
-  #     - name: acc_norm,none
-  #       value: 0.28
-
-  # - name: leaderboard_bbh_web_of_lies
-  #   metrics:
-  #     - name: acc_norm,none
-  #       value: 0.536
+  - name: leaderboard_bbh_web_of_lies
+    metrics:
+      - name: acc_norm,none
+        value: 0.536
 
   # - name: leaderboard_gpqa_diamond
   #   metrics:

--- a/mistralai/Mistral-Small-24B-Instruct-2501/storage.yml
+++ b/mistralai/Mistral-Small-24B-Instruct-2501/storage.yml
@@ -1,0 +1,3 @@
+# storage configs for https://huggingface.co/mistralai/Mistral-Small-24B-Instruct-2501
+model: hf
+data: hf


### PR DESCRIPTION
SUMMARY:
Add accuracy model configuration for the mistralai/Mistral-Small-24B-Instruct-2501 model.

TEST PLAN:
the ground truth values are populated by running against a k8s-a100-duo instance using the nm-cicd/dmk/run-llm-eval-test branch that's currently under review.
The values need to be vetted by Research.
https://github.com/neuralmagic/nm-cicd/actions/runs/14448731767
