### PR TITLE
meta-llama/Llama-3.1-8B-Instruct

### DIFF
--- a/meta-llama/Llama-3.1-8B-Instruct/accuracy/client.yml
+++ b/meta-llama/Llama-3.1-8B-Instruct/accuracy/client.yml
@@ -1,7 +1,7 @@
-# llm-eval-test configs for https://huggingface.co/meta-llama/Meta-Llama-3.1-8B-Instruct
+# llm-eval-test configs for https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct
 model: "vllm"
 model_args:
-  pretrained: "meta-llama/Meta-Llama-3.1-8B-Instruct"
+  pretrained: "meta-llama/Llama-3.1-8B-Instruct"
 num_fewshot:
 apply_chat_template: true
 fewshot_as_multiturn: true

--- a/meta-llama/Llama-3.1-8B-Instruct/accuracy/client.yml
+++ b/meta-llama/Llama-3.1-8B-Instruct/accuracy/client.yml
@@ -1,8 +1,3 @@
 # llm-eval-test configs for https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct
-model: "vllm"
-model_args:
-  pretrained: "meta-llama/Llama-3.1-8B-Instruct"
-num_fewshot:
-apply_chat_template: true
-fewshot_as_multiturn: true
-add_bos_token: false
+model: "meta-llama/Llama-3.1-8B-Instruct"
+chat_template: true

--- a/meta-llama/Llama-3.1-8B-Instruct/accuracy/server.yml
+++ b/meta-llama/Llama-3.1-8B-Instruct/accuracy/server.yml
@@ -1,5 +1,5 @@
-# server configs for https://huggingface.co/meta-llama/Meta-Llama-3.1-8B-Instruct
-model: "meta-llama/Meta-Llama-3.1-8B-Instruct"
+# server configs for https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct
+model: "meta-llama/Llama-3.1-8B-Instruct"
 trust-remote-code: true
 enable-chunked-prefill: true
 max-model-len: 4096

--- a/meta-llama/Llama-3.1-8B-Instruct/accuracy/server.yml
+++ b/meta-llama/Llama-3.1-8B-Instruct/accuracy/server.yml
@@ -2,5 +2,4 @@
 model: "meta-llama/Meta-Llama-3.1-8B-Instruct"
 trust-remote-code: true
 enable-chunked-prefill: true
-tensor-parallel-size:
 max-model-len: 4096

--- a/meta-llama/Llama-3.1-8B-Instruct/accuracy/tasks.yml
+++ b/meta-llama/Llama-3.1-8B-Instruct/accuracy/tasks.yml
@@ -1,4 +1,4 @@
-# accuracy configs for https://huggingface.co/meta-llama/Meta-Llama-3.1-8B-Instruct
+# accuracy configs for https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct
 tasks:
   - name: leaderboard_math_algebra_hard
     metrics:

--- a/meta-llama/Llama-3.1-8B-Instruct/accuracy/tasks.yml
+++ b/meta-llama/Llama-3.1-8B-Instruct/accuracy/tasks.yml
@@ -3,172 +3,177 @@ tasks:
   - name: leaderboard_math_algebra_hard
     metrics:
       - name: exact_match,none
-        value: 0.656
+        value: 0.3159
 
   - name: leaderboard_math_counting_and_prob_hard
     metrics:
       - name: exact_match,none
-        value: 0.525
+        value: 0.0813
 
   - name: leaderboard_math_geometry_hard
     metrics:
       - name: exact_match,none
-        value: 0.438
+        value: 0.053
 
   - name: leaderboard_math_intermediate_algebra_hard
     metrics:
       - name: exact_match,none
-        value: 0.251
+        value: 0.025
 
   - name: leaderboard_math_num_theory_hard
     metrics:
       - name: exact_match,none
-        value: 0.455
+        value: 0.1168
 
   - name: leaderboard_math_prealgebra_hard
     metrics:
       - name: exact_match,none
-        value: 0.628
+        value: 0.3056
 
   - name: leaderboard_math_precalculus_hard
     metrics:
       - name: exact_match,none
-        value: 0.341
+        value: 0.0444
 
   - name: leaderboard_bbh_boolean_expressions
     metrics:
       - name: acc_norm,none
-        value: 0.84
+        value: 0.82
 
   - name: leaderboard_bbh_causal_judgement
     metrics:
       - name: acc_norm,none
-        value: 0.567
+        value: 0.5668
 
   - name: leaderboard_bbh_date_understanding
     metrics:
       - name: acc_norm,none
-        value: 0.552
+        value: 0.468
 
   - name: leaderboard_bbh_disambiguation_qa
     metrics:
       - name: acc_norm,none
-        value: 0.688
+        value: 0.532
 
   - name: leaderboard_bbh_formal_fallacies
     metrics:
       - name: acc_norm,none
-        value: 0.64
+        value: 0.556
 
   - name: leaderboard_bbh_geometric_shapes
     metrics:
       - name: acc_norm,none
-        value: 0.516
+        value: 0.34
 
   - name: leaderboard_bbh_hyperbaton
     metrics:
       - name: acc_norm,none
-        value: 0.536
+        value: 0.628
 
   - name: leaderboard_bbh_logical_deduction_five_objects
     metrics:
       - name: acc_norm,none
-        value: 0.532
+        value: 0.42
 
   - name: leaderboard_bbh_logical_deduction_seven_objects
     metrics:
       - name: acc_norm,none
-        value: 0.496
+        value: 0.42
 
   - name: leaderboard_bbh_logical_deduction_three_objects
     metrics:
       - name: acc_norm,none
-        value: 0.74
+        value: 0.684
 
   - name: leaderboard_bbh_movie_recommendation
     metrics:
       - name: acc_norm,none
-        value: 0.664
+        value: 0.64
 
   - name: leaderboard_bbh_navigate
     metrics:
       - name: acc_norm,none
-        value: 0.68
+        value: 0.552
 
   - name: leaderboard_bbh_object_counting
     metrics:
       - name: acc_norm,none
-        value: 0.404
+        value: 0.464
 
   - name: leaderboard_bbh_penguins_in_a_table
     metrics:
       - name: acc_norm,none
-        value: 0.562
+        value: 0.452
 
   - name: leaderboard_bbh_reasoning_about_colored_objects
     metrics:
       - name: acc_norm,none
-        value: 0.624
+        value: 0.6
 
   - name: leaderboard_bbh_ruin_names
     metrics:
       - name: acc_norm,none
-        value: 0.616
+        value: 0.648
 
   - name: leaderboard_bbh_salient_translation_error_detection
     metrics:
       - name: acc_norm,none
-        value: 0.536
+        value: 0.512
 
   - name: leaderboard_bbh_snarks
     metrics:
       - name: acc_norm,none
-        value: 0.719
+        value: 0.617
 
   - name: leaderboard_bbh_sports_understanding
     metrics:
       - name: acc_norm,none
-        value: 0.684
+        value: 0.668
 
   - name: leaderboard_bbh_temporal_sequences
     metrics:
       - name: acc_norm,none
-        value: 0.544
+        value: 0.352
 
   - name: leaderboard_bbh_tracking_shuffled_objects_five_objects
     metrics:
       - name: acc_norm,none
-        value: 0.208
+        value: 0.212
 
   - name: leaderboard_bbh_tracking_shuffled_objects_seven_objects
     metrics:
       - name: acc_norm,none
-        value: 0.156
+        value: 0.152
 
   - name: leaderboard_bbh_tracking_shuffled_objects_three_objects
     metrics:
       - name: acc_norm,none
-        value: 0.28
+        value: 0.36
 
   - name: leaderboard_bbh_web_of_lies
     metrics:
       - name: acc_norm,none
-        value: 0.536
+        value: 0.544
 
   - name: leaderboard_gpqa_diamond
     metrics:
       - name: acc_norm,none
-        value: 0.345
+        value: 0.3131
 
   - name: leaderboard_gpqa_extended
     metrics:
       - name: acc_norm,none
-        value: 0.308
+        value: 0.2875
 
   - name: leaderboard_gpqa_main
     metrics:
       - name: acc_norm,none
-        value: 0.312
+        value: 0.3504
+
+  - name: leaderboard_mmlu_pro
+    metrics:
+      - name: acc,none
+        value: 3798
 
   - name: leaderboard_musr_murder_mysteries
     metrics:
@@ -178,20 +183,20 @@ tasks:
   - name: leaderboard_musr_object_placements
     metrics:
       - name: acc_norm,none
-        value: 0.367
+        value: 0.3554
 
   - name: leaderboard_musr_team_allocation
     metrics:
       - name: acc_norm,none
-        value: 0.388
+        value: 0.304
 
   - name: leaderboard_ifeval
     metrics:
       - name: prompt_level_strict_acc,none
-        value: 0.858
+        value: 0.4195
       - name: prompt_level_loose_acc,none
-        value: 0.824
+        value: 0.4584
       - name: inst_level_loose_acc,none
-        value: 0.797
+        value: 0.5947
       - name: inst_level_strict_acc,none
-        value: 0.749
+        value: 0.5647

--- a/meta-llama/Llama-3.1-8B-Instruct/accuracy/tasks.yml
+++ b/meta-llama/Llama-3.1-8B-Instruct/accuracy/tasks.yml
@@ -1,28 +1,197 @@
 # accuracy configs for https://huggingface.co/meta-llama/Meta-Llama-3.1-8B-Instruct
 tasks:
-- name: "leaderboard_bbh"
-  metrics:
-  - name: "acc_norm,none"
-    value: 0.50946
-- name: "leaderboard_gpqa"
-  metrics:
-  - name: "acc_norm,none"
-    value: 0.29698
-- name: "leaderboard_ifeval"
-  metrics:
-  - name: "inst_level_loose_acc,none"
-    value: 0.85851
-  - name: "inst_level_strict_acc,none"
-    value: 0.82374
-  - name: "prompt_level_loose_acc,none"
-    value: 0.79667
-  - name: "prompt_level_strict_acc,none"
-    value: 0.74861
-- name: "leaderboard_math_hard"
-  metrics:
-  - name: "exact_match,none"
-    value: 0.19864
-- name: "leaderboard_musr"
-  metrics:
-  - name: "acc_norm,none"
-    value: 0.38359
+  - name: leaderboard_math_algebra_hard
+    metrics:
+      - name: exact_match,none
+        value: 0.656
+
+  - name: leaderboard_math_counting_and_prob_hard
+    metrics:
+      - name: exact_match,none
+        value: 0.525
+
+  - name: leaderboard_math_geometry_hard
+    metrics:
+      - name: exact_match,none
+        value: 0.438
+
+  - name: leaderboard_math_intermediate_algebra_hard
+    metrics:
+      - name: exact_match,none
+        value: 0.251
+
+  - name: leaderboard_math_num_theory_hard
+    metrics:
+      - name: exact_match,none
+        value: 0.455
+
+  - name: leaderboard_math_prealgebra_hard
+    metrics:
+      - name: exact_match,none
+        value: 0.628
+
+  - name: leaderboard_math_precalculus_hard
+    metrics:
+      - name: exact_match,none
+        value: 0.341
+
+  - name: leaderboard_bbh_boolean_expressions
+    metrics:
+      - name: acc_norm,none
+        value: 0.84
+
+  - name: leaderboard_bbh_causal_judgement
+    metrics:
+      - name: acc_norm,none
+        value: 0.567
+
+  - name: leaderboard_bbh_date_understanding
+    metrics:
+      - name: acc_norm,none
+        value: 0.552
+
+  - name: leaderboard_bbh_disambiguation_qa
+    metrics:
+      - name: acc_norm,none
+        value: 0.688
+
+  - name: leaderboard_bbh_formal_fallacies
+    metrics:
+      - name: acc_norm,none
+        value: 0.64
+
+  - name: leaderboard_bbh_geometric_shapes
+    metrics:
+      - name: acc_norm,none
+        value: 0.516
+
+  - name: leaderboard_bbh_hyperbaton
+    metrics:
+      - name: acc_norm,none
+        value: 0.536
+
+  - name: leaderboard_bbh_logical_deduction_five_objects
+    metrics:
+      - name: acc_norm,none
+        value: 0.532
+
+  - name: leaderboard_bbh_logical_deduction_seven_objects
+    metrics:
+      - name: acc_norm,none
+        value: 0.496
+
+  - name: leaderboard_bbh_logical_deduction_three_objects
+    metrics:
+      - name: acc_norm,none
+        value: 0.74
+
+  - name: leaderboard_bbh_movie_recommendation
+    metrics:
+      - name: acc_norm,none
+        value: 0.664
+
+  - name: leaderboard_bbh_navigate
+    metrics:
+      - name: acc_norm,none
+        value: 0.68
+
+  - name: leaderboard_bbh_object_counting
+    metrics:
+      - name: acc_norm,none
+        value: 0.404
+
+  - name: leaderboard_bbh_penguins_in_a_table
+    metrics:
+      - name: acc_norm,none
+        value: 0.562
+
+  - name: leaderboard_bbh_reasoning_about_colored_objects
+    metrics:
+      - name: acc_norm,none
+        value: 0.624
+
+  - name: leaderboard_bbh_ruin_names
+    metrics:
+      - name: acc_norm,none
+        value: 0.616
+
+  - name: leaderboard_bbh_salient_translation_error_detection
+    metrics:
+      - name: acc_norm,none
+        value: 0.536
+
+  - name: leaderboard_bbh_snarks
+    metrics:
+      - name: acc_norm,none
+        value: 0.719
+
+  - name: leaderboard_bbh_sports_understanding
+    metrics:
+      - name: acc_norm,none
+        value: 0.684
+
+  - name: leaderboard_bbh_temporal_sequences
+    metrics:
+      - name: acc_norm,none
+        value: 0.544
+
+  - name: leaderboard_bbh_tracking_shuffled_objects_five_objects
+    metrics:
+      - name: acc_norm,none
+        value: 0.208
+
+  - name: leaderboard_bbh_tracking_shuffled_objects_seven_objects
+    metrics:
+      - name: acc_norm,none
+        value: 0.156
+
+  - name: leaderboard_bbh_tracking_shuffled_objects_three_objects
+    metrics:
+      - name: acc_norm,none
+        value: 0.28
+
+  - name: leaderboard_bbh_web_of_lies
+    metrics:
+      - name: acc_norm,none
+        value: 0.536
+
+  - name: leaderboard_gpqa_diamond
+    metrics:
+      - name: acc_norm,none
+        value: 0.345
+
+  - name: leaderboard_gpqa_extended
+    metrics:
+      - name: acc_norm,none
+        value: 0.308
+
+  - name: leaderboard_gpqa_main
+    metrics:
+      - name: acc_norm,none
+        value: 0.312
+
+  - name: leaderboard_musr_murder_mysteries
+    metrics:
+      - name: acc_norm,none
+        value: 0.532
+
+  - name: leaderboard_musr_object_placements
+    metrics:
+      - name: acc_norm,none
+        value: 0.367
+
+  - name: leaderboard_musr_team_allocation
+    metrics:
+      - name: acc_norm,none
+        value: 0.388
+
+  - name: leaderboard_ifeval
+    metrics:
+      - name: prompt_level_strict_acc,none
+        value: 0.858
+      - name: prompt_level_loose_acc,none
+        value: 0.824
+      - name: inst_level_loose_acc,none
+        value: 0.797
+      - name: inst_level_strict_acc,none
+        value: 0.749


### PR DESCRIPTION
SUMMARY:
Add accuracy model configuration for the meta-llama/Llama-3.1-8B-Instruct model.

TEST PLAN:
this is just a population of the model configuration files as place holders, with task metric values from huggingface
