### PR TITLE
meta-llama/Llama-3.3-70B-Instruct

### DIFF
--- a/meta-llama/Llama-3.3-70B-Instruct/accuracy/client.yml
+++ b/meta-llama/Llama-3.3-70B-Instruct/accuracy/client.yml
@@ -1,0 +1,7 @@
+# https://huggingface.co/meta-llama/Llama-3.3-70B-Instruct
+model: "vllm"
+model_args:
+  pretrained: "meta-llama/Llama-3.3-70B-Instruct"
+num_fewshot: null
+apply_chat_template: true
+fewshot_as_multiturn: true

--- a/meta-llama/Llama-3.3-70B-Instruct/accuracy/client.yml
+++ b/meta-llama/Llama-3.3-70B-Instruct/accuracy/client.yml
@@ -1,7 +1,3 @@
 # https://huggingface.co/meta-llama/Llama-3.3-70B-Instruct
-model: "vllm"
-model_args:
-  pretrained: "meta-llama/Llama-3.3-70B-Instruct"
-num_fewshot: null
-apply_chat_template: true
-fewshot_as_multiturn: true
+model: "meta-llama/Llama-3.3-70B-Instruct"
+chat_template: true

--- a/meta-llama/Llama-3.3-70B-Instruct/accuracy/server.yml
+++ b/meta-llama/Llama-3.3-70B-Instruct/accuracy/server.yml
@@ -2,3 +2,4 @@
 model: "meta-llama/Llama-3.3-70B-Instruct"
 trust_remote_code: True
 add_bos_token: False
+tool-call-parser: llama3_json

--- a/meta-llama/Llama-3.3-70B-Instruct/accuracy/server.yml
+++ b/meta-llama/Llama-3.3-70B-Instruct/accuracy/server.yml
@@ -1,0 +1,4 @@
+# https://huggingface.co/meta-llama/Llama-3.3-70B-Instruct
+model: "meta-llama/Llama-3.3-70B-Instruct"
+trust_remote_code: True
+add_bos_token: False

--- a/meta-llama/Llama-3.3-70B-Instruct/accuracy/tasks.yml
+++ b/meta-llama/Llama-3.3-70B-Instruct/accuracy/tasks.yml
@@ -1,0 +1,196 @@
+tasks:
+  - name: leaderboard_math_algebra_hard
+    metrics:
+      - name: exact_match,none
+        value: 0.656
+
+  - name: leaderboard_math_counting_and_prob_hard
+    metrics:
+      - name: exact_match,none
+        value: 0.525
+
+  - name: leaderboard_math_geometry_hard
+    metrics:
+      - name: exact_match,none
+        value: 0.438
+
+  - name: leaderboard_math_intermediate_algebra_hard
+    metrics:
+      - name: exact_match,none
+        value: 0.251
+
+  - name: leaderboard_math_num_theory_hard
+    metrics:
+      - name: exact_match,none
+        value: 0.455
+
+  - name: leaderboard_math_prealgebra_hard
+    metrics:
+      - name: exact_match,none
+        value: 0.628
+
+  - name: leaderboard_math_precalculus_hard
+    metrics:
+      - name: exact_match,none
+        value: 0.341
+
+  - name: leaderboard_bbh_boolean_expressions
+    metrics:
+      - name: acc_norm,none
+        value: 0.84
+
+  - name: leaderboard_bbh_causal_judgement
+    metrics:
+      - name: acc_norm,none
+        value: 0.567
+
+  - name: leaderboard_bbh_date_understanding
+    metrics:
+      - name: acc_norm,none
+        value: 0.552
+
+  - name: leaderboard_bbh_disambiguation_qa
+    metrics:
+      - name: acc_norm,none
+        value: 0.688
+
+  - name: leaderboard_bbh_formal_fallacies
+    metrics:
+      - name: acc_norm,none
+        value: 0.64
+
+  - name: leaderboard_bbh_geometric_shapes
+    metrics:
+      - name: acc_norm,none
+        value: 0.516
+
+  - name: leaderboard_bbh_hyperbaton
+    metrics:
+      - name: acc_norm,none
+        value: 0.536
+
+  - name: leaderboard_bbh_logical_deduction_five_objects
+    metrics:
+      - name: acc_norm,none
+        value: 0.532
+
+  - name: leaderboard_bbh_logical_deduction_seven_objects
+    metrics:
+      - name: acc_norm,none
+        value: 0.496
+
+  - name: leaderboard_bbh_logical_deduction_three_objects
+    metrics:
+      - name: acc_norm,none
+        value: 0.74
+
+  - name: leaderboard_bbh_movie_recommendation
+    metrics:
+      - name: acc_norm,none
+        value: 0.664
+
+  - name: leaderboard_bbh_navigate
+    metrics:
+      - name: acc_norm,none
+        value: 0.68
+
+  - name: leaderboard_bbh_object_counting
+    metrics:
+      - name: acc_norm,none
+        value: 0.404
+
+  - name: leaderboard_bbh_penguins_in_a_table
+    metrics:
+      - name: acc_norm,none
+        value: 0.562
+
+  - name: leaderboard_bbh_reasoning_about_colored_objects
+    metrics:
+      - name: acc_norm,none
+        value: 0.624
+
+  - name: leaderboard_bbh_ruin_names
+    metrics:
+      - name: acc_norm,none
+        value: 0.616
+
+  - name: leaderboard_bbh_salient_translation_error_detection
+    metrics:
+      - name: acc_norm,none
+        value: 0.536
+
+  - name: leaderboard_bbh_snarks
+    metrics:
+      - name: acc_norm,none
+        value: 0.719
+
+  - name: leaderboard_bbh_sports_understanding
+    metrics:
+      - name: acc_norm,none
+        value: 0.684
+
+  - name: leaderboard_bbh_temporal_sequences
+    metrics:
+      - name: acc_norm,none
+        value: 0.544
+
+  - name: leaderboard_bbh_tracking_shuffled_objects_five_objects
+    metrics:
+      - name: acc_norm,none
+        value: 0.208
+
+  - name: leaderboard_bbh_tracking_shuffled_objects_seven_objects
+    metrics:
+      - name: acc_norm,none
+        value: 0.156
+
+  - name: leaderboard_bbh_tracking_shuffled_objects_three_objects
+    metrics:
+      - name: acc_norm,none
+        value: 0.28
+
+  - name: leaderboard_bbh_web_of_lies
+    metrics:
+      - name: acc_norm,none
+        value: 0.536
+
+  - name: leaderboard_gpqa_diamond
+    metrics:
+      - name: acc_norm,none
+        value: 0.345
+
+  - name: leaderboard_gpqa_extended
+    metrics:
+      - name: acc_norm,none
+        value: 0.308
+
+  - name: leaderboard_gpqa_main
+    metrics:
+      - name: acc_norm,none
+        value: 0.312
+
+  - name: leaderboard_musr_murder_mysteries
+    metrics:
+      - name: acc_norm,none
+        value: 0.532
+
+  - name: leaderboard_musr_object_placements
+    metrics:
+      - name: acc_norm,none
+        value: 0.367
+
+  - name: leaderboard_musr_team_allocation
+    metrics:
+      - name: acc_norm,none
+        value: 0.388
+
+  - name: leaderboard_ifeval
+    metrics:
+      - name: prompt_level_strict_acc,none
+        value: 0.582
+      - name: prompt_level_loose_acc,none
+        value: 0.647
+      - name: inst_level_loose_acc,none
+        value: 0.748
+      - name: inst_level_strict_acc,none
+        value: 0.693

--- a/meta-llama/Llama-3.3-70B-Instruct/accuracy/tasks.yml
+++ b/meta-llama/Llama-3.3-70B-Instruct/accuracy/tasks.yml
@@ -2,195 +2,195 @@ tasks:
   - name: leaderboard_math_algebra_hard
     metrics:
       - name: exact_match,none
-        value: 0.656
+        value: 0.0
 
   - name: leaderboard_math_counting_and_prob_hard
     metrics:
       - name: exact_match,none
-        value: 0.525
+        value: 0.0
 
   - name: leaderboard_math_geometry_hard
     metrics:
       - name: exact_match,none
-        value: 0.438
+        value: 0.0
 
   - name: leaderboard_math_intermediate_algebra_hard
     metrics:
       - name: exact_match,none
-        value: 0.251
+        value: 0.0
 
   - name: leaderboard_math_num_theory_hard
     metrics:
       - name: exact_match,none
-        value: 0.455
+        value: 0.0064
 
   - name: leaderboard_math_prealgebra_hard
     metrics:
       - name: exact_match,none
-        value: 0.628
+        value: 0.0103
 
   - name: leaderboard_math_precalculus_hard
     metrics:
       - name: exact_match,none
-        value: 0.341
+        value: 0.0
 
   - name: leaderboard_bbh_boolean_expressions
     metrics:
       - name: acc_norm,none
-        value: 0.84
+        value: 0.916
 
   - name: leaderboard_bbh_causal_judgement
     metrics:
       - name: acc_norm,none
-        value: 0.567
+        value: 0.6791
 
   - name: leaderboard_bbh_date_understanding
     metrics:
       - name: acc_norm,none
-        value: 0.552
+        value: 0.704
 
   - name: leaderboard_bbh_disambiguation_qa
     metrics:
       - name: acc_norm,none
-        value: 0.688
+        value: 0.664
 
   - name: leaderboard_bbh_formal_fallacies
     metrics:
       - name: acc_norm,none
-        value: 0.64
+        value: 0.82
 
   - name: leaderboard_bbh_geometric_shapes
     metrics:
       - name: acc_norm,none
-        value: 0.516
+        value: 0.352
 
   - name: leaderboard_bbh_hyperbaton
     metrics:
       - name: acc_norm,none
-        value: 0.536
+        value: 0.708
 
   - name: leaderboard_bbh_logical_deduction_five_objects
     metrics:
       - name: acc_norm,none
-        value: 0.532
+        value: 0.656
 
   - name: leaderboard_bbh_logical_deduction_seven_objects
     metrics:
       - name: acc_norm,none
-        value: 0.496
+        value: 0.624
 
   - name: leaderboard_bbh_logical_deduction_three_objects
     metrics:
       - name: acc_norm,none
-        value: 0.74
+        value: 0.92
 
   - name: leaderboard_bbh_movie_recommendation
     metrics:
       - name: acc_norm,none
-        value: 0.664
+        value: 0.784
 
   - name: leaderboard_bbh_navigate
     metrics:
       - name: acc_norm,none
-        value: 0.68
+        value: 0.696
 
   - name: leaderboard_bbh_object_counting
     metrics:
       - name: acc_norm,none
-        value: 0.404
+        value: 0.58
 
   - name: leaderboard_bbh_penguins_in_a_table
     metrics:
       - name: acc_norm,none
-        value: 0.562
+        value: 0.6438
 
   - name: leaderboard_bbh_reasoning_about_colored_objects
     metrics:
       - name: acc_norm,none
-        value: 0.624
+        value: 0.892
 
   - name: leaderboard_bbh_ruin_names
     metrics:
       - name: acc_norm,none
-        value: 0.616
+        value: 0.852
 
   - name: leaderboard_bbh_salient_translation_error_detection
     metrics:
       - name: acc_norm,none
-        value: 0.536
+        value: 0.672
 
   - name: leaderboard_bbh_snarks
     metrics:
       - name: acc_norm,none
-        value: 0.719
+        value: 0.8033
 
   - name: leaderboard_bbh_sports_understanding
     metrics:
       - name: acc_norm,none
-        value: 0.684
+        value: 0.952
 
   - name: leaderboard_bbh_temporal_sequences
     metrics:
       - name: acc_norm,none
-        value: 0.544
+        value: 1.0
 
   - name: leaderboard_bbh_tracking_shuffled_objects_five_objects
     metrics:
       - name: acc_norm,none
-        value: 0.208
+        value: 0.324
 
   - name: leaderboard_bbh_tracking_shuffled_objects_seven_objects
     metrics:
       - name: acc_norm,none
-        value: 0.156
+        value: 0.26
 
   - name: leaderboard_bbh_tracking_shuffled_objects_three_objects
     metrics:
       - name: acc_norm,none
-        value: 0.28
+        value: 0.36
 
   - name: leaderboard_bbh_web_of_lies
     metrics:
       - name: acc_norm,none
-        value: 0.536
+        value: 0.744
 
   - name: leaderboard_gpqa_diamond
     metrics:
       - name: acc_norm,none
-        value: 0.345
+        value: 0.2929
 
   - name: leaderboard_gpqa_extended
     metrics:
       - name: acc_norm,none
-        value: 0.308
+        value: 0.3424
 
   - name: leaderboard_gpqa_main
     metrics:
       - name: acc_norm,none
-        value: 0.312
+        value: 0.3281
 
   - name: leaderboard_musr_murder_mysteries
     metrics:
       - name: acc_norm,none
-        value: 0.532
+        value: 0.536
 
   - name: leaderboard_musr_object_placements
     metrics:
       - name: acc_norm,none
-        value: 0.367
+        value: 0.2343
 
   - name: leaderboard_musr_team_allocation
     metrics:
       - name: acc_norm,none
-        value: 0.388
+        value: 0.568
 
   - name: leaderboard_ifeval
     metrics:
       - name: prompt_level_strict_acc,none
-        value: 0.582
+        value: 0.8798
       - name: prompt_level_loose_acc,none
-        value: 0.647
+        value: 0.8927
       - name: inst_level_loose_acc,none
-        value: 0.748
+        value: 0.928
       - name: inst_level_strict_acc,none
-        value: 0.693
+        value: 0.9196

--- a/meta-llama/Llama-3.3-70B-Instruct/storage.yml
+++ b/meta-llama/Llama-3.3-70B-Instruct/storage.yml
@@ -1,0 +1,3 @@
+# https://huggingface.co/meta-llama/Llama-3.3-70B-Instruct
+model: hf
+data: hf


### PR DESCRIPTION
SUMMARY:
Add accuracy model configuration for the meta-llama/Llama-3.3-70B-Instruct model.

TEST PLAN:
this just fills in the accuracy files for model validation, populating the task metric values from Hugging Face OpenLLM Leaderboard v2 https://huggingface.co/datasets/open-llm-leaderboard/meta-llama__Llama-3.3-70B-Instruct-details