### PR TITLE
llama-3.1-8b-instruct tasks

### DIFF
--- a/RedHatAI/Meta-Llama-3.1-8B-Instruct-FP8-dynamic/accuracy/tasks.yml
+++ b/RedHatAI/Meta-Llama-3.1-8B-Instruct-FP8-dynamic/accuracy/tasks.yml
@@ -2,7 +2,7 @@ tasks:
   - name: arc-challenge
     metrics:
       - name: acc-norm,none
-        value: 0.82
+        value: 0.812
 
   # - name: gsm8k_cot_llama_3.1_instruct
   #   metrics:
@@ -12,53 +12,53 @@ tasks:
   - name: hellaswag
     metrics:
       - name: acc-norm,none
-        value: 0.805
+        value: 0.8
 
   - name: mmlu
     metrics:
       - name: acc,none
-        value: 0.6795
+        value: 0.6802
 
   - name: truthfulqa
     metrics:
       - name: mc2,none
-        value: 0.545
+        value: 0.543
 
   - name: winogrande
     metrics:
       - name: acc,none
-        value: 0.785
+        value: 0.777
 
   # - name: leaderboard_ifeval
   #   metrics:
   #     - name: inst_level_strict_acc,none
-  #       value: 0.779
+  #       value: 0.772
 
   # - name: leaderboard_bbh
   #   metrics:
   #     - name: acc-norm,none
-  #       value: 0.301
+  #       value: 0.297
 
   # TODO: need to identify if this is available
   # - name: leaderboard_math_v_5
   #   metrics:
   #     - name: exact_match,none
-  #       value: 0.157
+  #       value: 0.1666
 
   # - name: leaderboard_gpqa
   #   metrics:
   #     - name: acc-norm,none
-  #       value: 0.037
+  #       value: 0.057
 
   # - name: leaderboard_musr
   #   metrics:
   #     - name: acc-norm,none
-  #       value: 0.076
+  #       value: 0.075
 
   # - name: leaderboard_mmlu_pro
   #   metrics:
   #     - name: acc,none
-  #       value: 0.308
+  #       value: 0.3423
 
   # - name: humaneval
   #   metrics:

--- a/RedHatAI/Meta-Llama-3.1-8B-Instruct-FP8-dynamic/accuracy/tasks.yml
+++ b/RedHatAI/Meta-Llama-3.1-8B-Instruct-FP8-dynamic/accuracy/tasks.yml
@@ -11,7 +11,7 @@ tasks:
 
   - name: hellaswag
     metrics:
-      - name: acc-norm,none
+      - name: acc_norm,none
         value: 0.8
 
   - name: mmlu
@@ -19,9 +19,9 @@ tasks:
       - name: acc,none
         value: 0.6802
 
-  - name: truthfulqa
+  - name: truthfulqa_mc2
     metrics:
-      - name: mc2,none
+      - name: acc,none
         value: 0.543
 
   - name: winogrande

--- a/RedHatAI/Meta-Llama-3.1-8B-Instruct-FP8-dynamic/accuracy/tasks.yml
+++ b/RedHatAI/Meta-Llama-3.1-8B-Instruct-FP8-dynamic/accuracy/tasks.yml
@@ -1,7 +1,7 @@
 tasks:
-  - name: arc-challenge
+  - name: arc_challenge
     metrics:
-      - name: acc-norm,none
+      - name: acc_norm,none
         value: 0.812
 
   # - name: gsm8k_cot_llama_3.1_instruct

--- a/RedHatAI/Meta-Llama-3.1-8B-Instruct-quantized.w4a16/accuracy/tasks.yml
+++ b/RedHatAI/Meta-Llama-3.1-8B-Instruct-quantized.w4a16/accuracy/tasks.yml
@@ -2,65 +2,65 @@ tasks:
   - name: arc-challenge
     metrics:
       - name: acc-norm,none
-        value: 0.82
+        value: 0.802
 
   # - name: gsm8k_cot_llama_3.1_instruct
   #   metrics:
   #     - name: strict_match,none
-  #       value: 0.82
+  #       value: 0.829
 
   - name: hellaswag
     metrics:
       - name: acc-norm,none
-        value: 0.805
+        value: 0.799
 
   - name: mmlu
     metrics:
       - name: acc,none
-        value: 0.6795
+        value: 0.669
 
   - name: truthfulqa
     metrics:
       - name: mc2,none
-        value: 0.545
+        value: 0.528
 
   - name: winogrande
     metrics:
       - name: acc,none
-        value: 0.785
+        value: 0.78
 
   # - name: leaderboard_ifeval
   #   metrics:
   #     - name: inst_level_strict_acc,none
-  #       value: 0.779
+  #       value: 0.763
 
   # - name: leaderboard_bbh
   #   metrics:
   #     - name: acc-norm,none
-  #       value: 0.301
+  #       value: 0.289
 
   # TODO: need to identify if this is available
   # - name: leaderboard_math_v_5
   #   metrics:
   #     - name: exact_match,none
-  #       value: 0.157
+  #       value: 0.148
 
   # - name: leaderboard_gpqa
   #   metrics:
   #     - name: acc-norm,none
-  #       value: 0.037
+  #       value: 0.04
 
   # - name: leaderboard_musr
   #   metrics:
   #     - name: acc-norm,none
-  #       value: 0.076
+  #       value: 0.063
 
   # - name: leaderboard_mmlu_pro
   #   metrics:
   #     - name: acc,none
-  #       value: 0.308
+  #       value: 0.288
 
   # - name: humaneval
   #   metrics:
   #     - name: exact_match,none
-  #       value: 0.673
+  #       value: 0.671

--- a/RedHatAI/Meta-Llama-3.1-8B-Instruct-quantized.w4a16/accuracy/tasks.yml
+++ b/RedHatAI/Meta-Llama-3.1-8B-Instruct-quantized.w4a16/accuracy/tasks.yml
@@ -11,7 +11,7 @@ tasks:
 
   - name: hellaswag
     metrics:
-      - name: acc-norm,none
+      - name: acc_norm,none
         value: 0.799
 
   - name: mmlu
@@ -19,9 +19,9 @@ tasks:
       - name: acc,none
         value: 0.669
 
-  - name: truthfulqa
+  - name: truthfulqa_mc2
     metrics:
-      - name: mc2,none
+      - name: acc,none
         value: 0.528
 
   - name: winogrande

--- a/RedHatAI/Meta-Llama-3.1-8B-Instruct-quantized.w4a16/accuracy/tasks.yml
+++ b/RedHatAI/Meta-Llama-3.1-8B-Instruct-quantized.w4a16/accuracy/tasks.yml
@@ -1,7 +1,7 @@
 tasks:
-  - name: arc-challenge
+  - name: arc_challenge
     metrics:
-      - name: acc-norm,none
+      - name: acc_norm,none
         value: 0.802
 
   # - name: gsm8k_cot_llama_3.1_instruct

--- a/RedHatAI/Meta-Llama-3.1-8B-Instruct-quantized.w8a8/accuracy/tasks.yml
+++ b/RedHatAI/Meta-Llama-3.1-8B-Instruct-quantized.w8a8/accuracy/tasks.yml
@@ -11,7 +11,7 @@ tasks:
 
   - name: hellaswag
     metrics:
-      - name: acc-norm,none
+      - name: acc_norm,none
         value: 0.803
 
   - name: mmlu
@@ -19,9 +19,9 @@ tasks:
       - name: acc,none
         value: 0.678
 
-  - name: truthfulqa
+  - name: truthfulqa_mc2
     metrics:
-      - name: mc2,none
+      - name: acc,none
         value: 0.547
 
   - name: winogrande

--- a/RedHatAI/Meta-Llama-3.1-8B-Instruct-quantized.w8a8/accuracy/tasks.yml
+++ b/RedHatAI/Meta-Llama-3.1-8B-Instruct-quantized.w8a8/accuracy/tasks.yml
@@ -2,27 +2,27 @@ tasks:
   - name: arc-challenge
     metrics:
       - name: acc-norm,none
-        value: 0.82
+        value: 0.817
 
   # - name: gsm8k_cot_llama_3.1_instruct
   #   metrics:
   #     - name: strict_match,none
-  #       value: 0.82
+  #       value: 0.848
 
   - name: hellaswag
     metrics:
       - name: acc-norm,none
-        value: 0.805
+        value: 0.803
 
   - name: mmlu
     metrics:
       - name: acc,none
-        value: 0.6795
+        value: 0.678
 
   - name: truthfulqa
     metrics:
       - name: mc2,none
-        value: 0.545
+        value: 0.547
 
   - name: winogrande
     metrics:
@@ -32,23 +32,23 @@ tasks:
   # - name: leaderboard_ifeval
   #   metrics:
   #     - name: inst_level_strict_acc,none
-  #       value: 0.779
+  #       value: 0.78
 
   # - name: leaderboard_bbh
   #   metrics:
   #     - name: acc-norm,none
-  #       value: 0.301
+  #       value: 0.31
 
   # TODO: need to identify if this is available
   # - name: leaderboard_math_v_5
   #   metrics:
   #     - name: exact_match,none
-  #       value: 0.157
+  #       value: 0.155
 
   # - name: leaderboard_gpqa
   #   metrics:
   #     - name: acc-norm,none
-  #       value: 0.037
+  #       value: 0.054
 
   # - name: leaderboard_musr
   #   metrics:
@@ -58,9 +58,9 @@ tasks:
   # - name: leaderboard_mmlu_pro
   #   metrics:
   #     - name: acc,none
-  #       value: 0.308
+  #       value: 0.309
 
   # - name: humaneval
   #   metrics:
   #     - name: exact_match,none
-  #       value: 0.673
+  #       value: 0.671

--- a/RedHatAI/Meta-Llama-3.1-8B-Instruct-quantized.w8a8/accuracy/tasks.yml
+++ b/RedHatAI/Meta-Llama-3.1-8B-Instruct-quantized.w8a8/accuracy/tasks.yml
@@ -1,7 +1,7 @@
 tasks:
-  - name: arc-challenge
+  - name: arc_challenge
     metrics:
-      - name: acc-norm,none
+      - name: acc_norm,none
         value: 0.817
 
   # - name: gsm8k_cot_llama_3.1_instruct

--- a/meta-llama/Llama-3.1-8B-Instruct/accuracy/tasks.yml
+++ b/meta-llama/Llama-3.1-8B-Instruct/accuracy/tasks.yml
@@ -11,7 +11,7 @@ tasks:
 
   - name: hellaswag
     metrics:
-      - name: acc-norm,none
+      - name: acc_norm,none
         value: 0.805
 
   - name: mmlu
@@ -19,9 +19,9 @@ tasks:
       - name: acc,none
         value: 0.6795
 
-  - name: truthfulqa
+  - name: truthfulqa_mc2
     metrics:
-      - name: mc2,none
+      - name: acc,none
         value: 0.545
 
   - name: winogrande

--- a/meta-llama/Llama-3.1-8B-Instruct/accuracy/tasks.yml
+++ b/meta-llama/Llama-3.1-8B-Instruct/accuracy/tasks.yml
@@ -1,8 +1,8 @@
 tasks:
-  - name: arc-challenge
-    metrics:
-      - name: acc-norm,none
-        value: 0.82
+  # - name: arc-challenge
+  #   metrics:
+  #     - name: acc-norm,none
+  #       value: 0.82
 
   # - name: gsm8k_cot_llama_3.1_instruct
   #   metrics:

--- a/meta-llama/Llama-3.1-8B-Instruct/accuracy/tasks.yml
+++ b/meta-llama/Llama-3.1-8B-Instruct/accuracy/tasks.yml
@@ -1,8 +1,8 @@
 tasks:
-  # - name: arc-challenge
-  #   metrics:
-  #     - name: acc-norm,none
-  #       value: 0.82
+  - name: arc_challenge
+    metrics:
+      - name: acc_norm,none
+        value: 0.814
 
   # - name: gsm8k_cot_llama_3.1_instruct
   #   metrics:


### PR DESCRIPTION
SUMMARY:
adds `task.yml` config files for the models derived from meta-llama/Llama-3.1-8B-Instruct.
The task metric values are from the model card for the specific model (though the values for the "parent" come from the one of the RedHatAI models, where the evaluation accuracy table shows the measured parent metrics).

TEST PLAN:
All runs are showing failures.  these are likely due to the fact that either the server or client do not have configuration settings set exactly as described in the model card's evaluation section.

* meta-llama/Llama-3.1-8B-Instruct  [accuracy](https://github.com/neuralmagic/nm-cicd/actions/runs/14521676472)
