### PR TITLE
add tasks.yml for microsoft/phi-4 models

### DIFF
--- a/RedHatAI/phi-4-FP8-dynamic/accuracy/tasks.yml
+++ b/RedHatAI/phi-4-FP8-dynamic/accuracy/tasks.yml
@@ -1,8 +1,8 @@
 tasks:
-  # - name: arc-challenge
-  #   metrics:
-  #     - name: acc-norm,none
-  #       value: 0.6425
+  - name: arc_challenge
+    metrics:
+      - name: acc_norm,none
+        value: 0.6425
 
   - name: gsm8k
     metrics:
@@ -11,7 +11,7 @@ tasks:
 
   - name: hellaswag
     metrics:
-      - name: acc-norm,none
+      - name: acc_norm,none
         value: 0.8419
 
   - name: mmlu
@@ -19,9 +19,9 @@ tasks:
       - name: acc,none
         value: 0.803
 
-  - name: truthfulqa
+  - name: truthfulqa_mc2
     metrics:
-      - name: mc2,none
+      - name: acc,none
         value: 0.5954
 
   - name: winogrande

--- a/RedHatAI/phi-4-FP8-dynamic/accuracy/tasks.yml
+++ b/RedHatAI/phi-4-FP8-dynamic/accuracy/tasks.yml
@@ -1,0 +1,30 @@
+tasks:
+  # - name: arc-challenge
+  #   metrics:
+  #     - name: acc-norm,none
+  #       value: 0.6425
+
+  - name: gsm8k
+    metrics:
+      - name: strict_match,none
+        value: 0.9067
+
+  - name: hellaswag
+    metrics:
+      - name: acc-norm,none
+        value: 0.8419
+
+  - name: mmlu
+    metrics:
+      - name: acc,none
+        value: 0.803
+
+  - name: truthfulqa
+    metrics:
+      - name: mc2,none
+        value: 0.5954
+
+  - name: winogrande
+    metrics:
+      - name: acc,none
+        value: 0.7987

--- a/RedHatAI/phi-4-FP8-dynamic/accuracy/tasks.yml
+++ b/RedHatAI/phi-4-FP8-dynamic/accuracy/tasks.yml
@@ -6,7 +6,7 @@ tasks:
 
   - name: gsm8k
     metrics:
-      - name: strict_match,none
+      - name: exact_match,strict-match
         value: 0.9067
 
   - name: hellaswag

--- a/RedHatAI/phi-4-quantized.w4a16/accuracy/tasks.yml
+++ b/RedHatAI/phi-4-quantized.w4a16/accuracy/tasks.yml
@@ -1,8 +1,8 @@
 tasks:
-  # - name: arc-challenge
-  #   metrics:
-  #     - name: acc-norm,none
-  #       value: 0.6288
+  - name: arc_challenge
+    metrics:
+      - name: acc_norm,none
+        value: 0.6288
 
   - name: gsm8k
     metrics:
@@ -11,7 +11,7 @@ tasks:
 
   - name: hellaswag
     metrics:
-      - name: acc-norm,none
+      - name: acc_norm,none
         value: 0.8342
 
   - name: mmlu
@@ -19,9 +19,9 @@ tasks:
       - name: acc,none
         value: 0.7987
 
-  - name: truthfulqa
+  - name: truthfulqa_mc2
     metrics:
-      - name: mc2,none
+      - name: acc,none
         value: 0.5918
 
   - name: winogrande

--- a/RedHatAI/phi-4-quantized.w4a16/accuracy/tasks.yml
+++ b/RedHatAI/phi-4-quantized.w4a16/accuracy/tasks.yml
@@ -6,7 +6,7 @@ tasks:
 
   - name: gsm8k
     metrics:
-      - name: strict_match,none
+      - name: exact_match,strict-match
         value: 0.8969
 
   - name: hellaswag

--- a/RedHatAI/phi-4-quantized.w4a16/accuracy/tasks.yml
+++ b/RedHatAI/phi-4-quantized.w4a16/accuracy/tasks.yml
@@ -1,0 +1,30 @@
+tasks:
+  # - name: arc-challenge
+  #   metrics:
+  #     - name: acc-norm,none
+  #       value: 0.6288
+
+  - name: gsm8k
+    metrics:
+      - name: strict_match,none
+        value: 0.8969
+
+  - name: hellaswag
+    metrics:
+      - name: acc-norm,none
+        value: 0.8342
+
+  - name: mmlu
+    metrics:
+      - name: acc,none
+        value: 0.7987
+
+  - name: truthfulqa
+    metrics:
+      - name: mc2,none
+        value: 0.5918
+
+  - name: winogrande
+    metrics:
+      - name: acc,none
+        value: 0.8074

--- a/RedHatAI/phi-4-quantized.w8a8/accuracy/tasks.yml
+++ b/RedHatAI/phi-4-quantized.w8a8/accuracy/tasks.yml
@@ -1,8 +1,8 @@
 tasks:
-  # - name: arc-challenge
-  #   metrics:
-  #     - name: acc-norm,none
-  #       value: 0.6433
+  - name: arc_challenge
+    metrics:
+      - name: acc_norm,none
+        value: 0.6433
 
   - name: gsm8k
     metrics:
@@ -11,7 +11,7 @@ tasks:
 
   - name: hellaswag
     metrics:
-      - name: acc-norm,none
+      - name: acc_norm,none
         value: 0.843
 
   - name: mmlu
@@ -19,9 +19,9 @@ tasks:
       - name: acc,none
         value: 0.8039
 
-  - name: truthfulqa
+  - name: truthfulqa_mc2
     metrics:
-      - name: mc2,none
+      - name: acc,none
         value: 0.5882
 
   - name: winogrande

--- a/RedHatAI/phi-4-quantized.w8a8/accuracy/tasks.yml
+++ b/RedHatAI/phi-4-quantized.w8a8/accuracy/tasks.yml
@@ -1,0 +1,30 @@
+tasks:
+  # - name: arc-challenge
+  #   metrics:
+  #     - name: acc-norm,none
+  #       value: 0.6433
+
+  - name: gsm8k
+    metrics:
+      - name: strict_match,none
+        value: 0.903
+
+  - name: hellaswag
+    metrics:
+      - name: acc-norm,none
+        value: 0.843
+
+  - name: mmlu
+    metrics:
+      - name: acc,none
+        value: 0.8039
+
+  - name: truthfulqa
+    metrics:
+      - name: mc2,none
+        value: 0.5882
+
+  - name: winogrande
+    metrics:
+      - name: acc,none
+        value: 0.7995

--- a/RedHatAI/phi-4-quantized.w8a8/accuracy/tasks.yml
+++ b/RedHatAI/phi-4-quantized.w8a8/accuracy/tasks.yml
@@ -6,7 +6,7 @@ tasks:
 
   - name: gsm8k
     metrics:
-      - name: strict_match,none
+      - name: exact_match,strict-match
         value: 0.903
 
   - name: hellaswag

--- a/microsoft/phi-4/accuracy/tasks.yml
+++ b/microsoft/phi-4/accuracy/tasks.yml
@@ -1,0 +1,30 @@
+tasks:
+  # - name: arc-challenge
+  #   metrics:
+  #     - name: acc-norm,none
+  #       value: 0.6442
+
+  - name: gsm8k
+    metrics:
+      - name: strict_match,none
+        value: 0.9007
+
+  - name: hellaswag
+    metrics:
+      - name: acc-norm,none
+        value: 0.8437
+
+  - name: mmlu
+    metrics:
+      - name: acc,none
+        value: 0.803
+
+  - name: truthfulqa
+    metrics:
+      - name: mc2,none
+        value: 0.5937
+
+  - name: winogrande
+    metrics:
+      - name: acc,none
+        value: 0.8058

--- a/microsoft/phi-4/accuracy/tasks.yml
+++ b/microsoft/phi-4/accuracy/tasks.yml
@@ -6,7 +6,7 @@ tasks:
 
   - name: gsm8k
     metrics:
-      - name: strict_match,none
+      - name: exact_match,strict-match
         value: 0.9007
 
   - name: hellaswag

--- a/microsoft/phi-4/accuracy/tasks.yml
+++ b/microsoft/phi-4/accuracy/tasks.yml
@@ -1,8 +1,8 @@
 tasks:
-  # - name: arc-challenge
-  #   metrics:
-  #     - name: acc-norm,none
-  #       value: 0.6442
+  - name: arc_challenge
+    metrics:
+      - name: acc_norm,none
+        value: 0.6442
 
   - name: gsm8k
     metrics:
@@ -11,7 +11,7 @@ tasks:
 
   - name: hellaswag
     metrics:
-      - name: acc-norm,none
+      - name: acc_norm,none
         value: 0.8437
 
   - name: mmlu
@@ -19,9 +19,9 @@ tasks:
       - name: acc,none
         value: 0.803
 
-  - name: truthfulqa
+  - name: truthfulqa_mc2
     metrics:
-      - name: mc2,none
+      - name: acc,none
         value: 0.5937
 
   - name: winogrande


### PR DESCRIPTION
SUMMARY:
adds task.yml config files for the models derived from microsoft/phi-4.
The task metric values are from the model card for the specific model (though the values for the "parent" come from the one of the RedHatAI models, where the evaluation accuracy table shows the measured parent metrics).

TEST PLAN:
All runs are showing failures. these are likely due to the fact that either the server or client do not have configuration settings set exactly as described in the model card's evaluation section.

* microsoft/phi-4 [accuracy](https://github.com/neuralmagic/nm-cicd/actions/runs/14523441381)
* RedHatAI/phi-4-quantized.w4a16 [accuracy](https://github.com/neuralmagic/nm-cicd/actions/runs/14525173023)
* RedHatAI/phi-4-quantized.w8a8 [accuracy](https://github.com/neuralmagic/nm-cicd/actions/runs/14525198543)
* RedHatAI/phi-4-FP8-dynamic [accuracy](https://github.com/neuralmagic/nm-cicd/actions/runs/14525230379)