### PR TITLE
add tasks.yml for Llama-3.3-70B-Instruct models

### DIFF
--- a/RedHatAI/Llama-3.3-70B-Instruct-FP8-dynamic/accuracy/tasks.yml
+++ b/RedHatAI/Llama-3.3-70B-Instruct-FP8-dynamic/accuracy/tasks.yml
@@ -29,6 +29,10 @@ tasks:
       - name: acc,none
         value: 0.8453
 
+  # following are placeholders for mid-level "leaderboard_*" tasks
+  # (OpenLLM v2) waiting for info on how to calculate the metric
+  # values from the individual sub tasks.
+
   # - name: leaderboard_ifeval
   #   metrics:
   #     - name: inst_level_strict_acc,none

--- a/RedHatAI/Llama-3.3-70B-Instruct-FP8-dynamic/accuracy/tasks.yml
+++ b/RedHatAI/Llama-3.3-70B-Instruct-FP8-dynamic/accuracy/tasks.yml
@@ -1,0 +1,66 @@
+tasks:
+  - name: arc_challenge
+    metrics:
+      - name: acc_norm,none
+        value: 0.5196
+
+  - name: gsm8k
+    metrics:
+      - name: strict_match,none
+        value: 0.9492
+
+  - name: hellaswag
+    metrics:
+      - name: acc_norm,none
+        value: 0.8643
+
+  - name: mmlu
+    metrics:
+      - name: acc,none
+        value: 0.8131
+
+  - name: truthfulqa_mc2
+    metrics:
+      - name: acc,none
+        value: 0.6321
+
+  - name: winogrande
+    metrics:
+      - name: acc,none
+        value: 0.8453
+
+  # - name: leaderboard_ifeval
+  #   metrics:
+  #     - name: inst_level_strict_acc,none
+  #       value: 0.9092
+
+  # - name: leaderboard_bbh
+  #   metrics:
+  #     - name: acc-norm,none
+  #       value: 0.6284
+
+  # TODO: need to identify if this is available
+  # - name: leaderboard_math_v_5
+  #   metrics:
+  #     - name: exact_match,none
+  #       value: 0.0033
+
+  # - name: leaderboard_gpqa
+  #   metrics:
+  #     - name: acc-norm,none
+  #       value: 0.463
+
+  # - name: leaderboard_musr
+  #   metrics:
+  #     - name: acc-norm,none
+  #       value: 0.4396
+
+  # - name: leaderboard_mmlu_pro
+  #   metrics:
+  #     - name: acc,none
+  #       value: 0.515
+
+  # - name: humaneval
+  #   metrics:
+  #     - name: exact_match,none
+  #       value: 0.837

--- a/RedHatAI/Llama-3.3-70B-Instruct-FP8-dynamic/accuracy/tasks.yml
+++ b/RedHatAI/Llama-3.3-70B-Instruct-FP8-dynamic/accuracy/tasks.yml
@@ -6,7 +6,7 @@ tasks:
 
   - name: gsm8k
     metrics:
-      - name: strict_match,none
+      - name: exact_match,strict-match
         value: 0.9492
 
   - name: hellaswag

--- a/RedHatAI/Llama-3.3-70B-Instruct-quantized.w4a16/accuracy/tasks.yml
+++ b/RedHatAI/Llama-3.3-70B-Instruct-quantized.w4a16/accuracy/tasks.yml
@@ -1,0 +1,31 @@
+tasks:
+  - name: arc_challenge
+    metrics:
+      - name: acc_norm,none
+        value: 0.4949
+
+  - name: gsm8k
+    metrics:
+      - name: strict_match,none
+        value: 0.9447
+
+  - name: hellaswag
+    metrics:
+      - name: acc_norm,none
+        value: 0.8597
+
+  - name: mmlu
+    metrics:
+      - name: acc,none
+        value: 0.8062
+
+  - name: truthfulqa_mc2
+    metrics:
+      - name: acc,none
+        value: 0.6166
+
+  # not available in model card as of 20250417
+  # - name: winogrande
+  #   metrics:
+  #     - name: acc,none
+  #       value: 0.8058

--- a/RedHatAI/Llama-3.3-70B-Instruct-quantized.w4a16/accuracy/tasks.yml
+++ b/RedHatAI/Llama-3.3-70B-Instruct-quantized.w4a16/accuracy/tasks.yml
@@ -6,7 +6,7 @@ tasks:
 
   - name: gsm8k
     metrics:
-      - name: strict_match,none
+      - name: exact_match,strict-match
         value: 0.9447
 
   - name: hellaswag

--- a/RedHatAI/Llama-3.3-70B-Instruct-quantized.w8a8/accuracy/tasks.yml
+++ b/RedHatAI/Llama-3.3-70B-Instruct-quantized.w8a8/accuracy/tasks.yml
@@ -29,6 +29,10 @@ tasks:
       - name: acc,none
         value: 0.8374
 
+  # following are placeholders for mid-level "leaderboard_*" tasks
+  # (OpenLLM v2) waiting for info on how to calculate the metric
+  # values from the individual sub tasks.
+
   # - name: leaderboard_ifeval
   #   metrics:
   #     - name: inst_level_strict_acc,none

--- a/RedHatAI/Llama-3.3-70B-Instruct-quantized.w8a8/accuracy/tasks.yml
+++ b/RedHatAI/Llama-3.3-70B-Instruct-quantized.w8a8/accuracy/tasks.yml
@@ -1,0 +1,66 @@
+tasks:
+  - name: arc_challenge
+    metrics:
+      - name: acc_norm,none
+        value: 0.4804
+
+  - name: gsm8k
+    metrics:
+      - name: strict_match,none
+        value: 0.9401
+
+  - name: hellaswag
+    metrics:
+      - name: acc_norm,none
+        value: 0.8647
+
+  - name: mmlu
+    metrics:
+      - name: acc,none
+        value: 0.8119
+
+  - name: truthfulqa_mc2
+    metrics:
+      - name: acc,none
+        value: 0.6309
+
+  - name: winogrande
+    metrics:
+      - name: acc,none
+        value: 0.8374
+
+  # - name: leaderboard_ifeval
+  #   metrics:
+  #     - name: inst_level_strict_acc,none
+  #       value: 0.9068
+
+  # - name: leaderboard_bbh
+  #   metrics:
+  #     - name: acc-norm,none
+  #       value: 0.6254
+
+  # TODO: need to identify if this is available
+  # - name: leaderboard_math_v_5
+  #   metrics:
+  #     - name: exact_match,none
+  #       value: 0
+
+  # - name: leaderboard_gpqa
+  #   metrics:
+  #     - name: acc-norm,none
+  #       value: 0.4644
+
+  # - name: leaderboard_musr
+  #   metrics:
+  #     - name: acc-norm,none
+  #       value: 0.4434
+
+  # - name: leaderboard_mmlu_pro
+  #   metrics:
+  #     - name: acc,none
+  #       value: 0.5159
+
+  # - name: humaneval
+  #   metrics:
+  #     - name: exact_match,none
+  #       value: 0.833

--- a/RedHatAI/Llama-3.3-70B-Instruct-quantized.w8a8/accuracy/tasks.yml
+++ b/RedHatAI/Llama-3.3-70B-Instruct-quantized.w8a8/accuracy/tasks.yml
@@ -6,7 +6,7 @@ tasks:
 
   - name: gsm8k
     metrics:
-      - name: strict_match,none
+      - name: exact_match,strict-match
         value: 0.9401
 
   - name: hellaswag

--- a/meta-llama/Llama-3.3-70B-Instruct/accuracy/tasks.yml
+++ b/meta-llama/Llama-3.3-70B-Instruct/accuracy/tasks.yml
@@ -29,6 +29,10 @@ tasks:
       - name: acc,none
         value: 0.8477
 
+  # following are placeholders for mid-level "leaderboard_*" tasks
+  # (OpenLLM v2) waiting for info on how to calculate the metric
+  # values from the individual sub tasks.
+
   # - name: leaderboard_ifeval
   #   metrics:
   #     - name: inst_level_strict_acc,none

--- a/meta-llama/Llama-3.3-70B-Instruct/accuracy/tasks.yml
+++ b/meta-llama/Llama-3.3-70B-Instruct/accuracy/tasks.yml
@@ -6,7 +6,7 @@ tasks:
 
   - name: gsm8k
     metrics:
-      - name: strict_match,none
+      - name: exact_match,strict-match
         value: 0.9416
 
   - name: hellaswag

--- a/meta-llama/Llama-3.3-70B-Instruct/accuracy/tasks.yml
+++ b/meta-llama/Llama-3.3-70B-Instruct/accuracy/tasks.yml
@@ -1,0 +1,66 @@
+tasks:
+  - name: arc_challenge
+    metrics:
+      - name: acc_norm,none
+        value: 0.4923
+
+  - name: gsm8k
+    metrics:
+      - name: strict_match,none
+        value: 0.9416
+
+  - name: hellaswag
+    metrics:
+      - name: acc_norm,none
+        value: 0.8649
+
+  - name: mmlu
+    metrics:
+      - name: acc,none
+        value: 0.816
+
+  - name: truthfulqa_mc2
+    metrics:
+      - name: acc,none
+        value: 0.6275
+
+  - name: winogrande
+    metrics:
+      - name: acc,none
+        value: 0.8477
+
+  # - name: leaderboard_ifeval
+  #   metrics:
+  #     - name: inst_level_strict_acc,none
+  #       value: 0.9089
+
+  # - name: leaderboard_bbh
+  #   metrics:
+  #     - name: acc-norm,none
+  #       value: 0.6315
+
+  # TODO: need to identify if this is available
+  # - name: leaderboard_math_v_5
+  #   metrics:
+  #     - name: exact_match,none
+  #       value: 0.0017
+
+  # - name: leaderboard_gpqa
+  #   metrics:
+  #     - name: acc-norm,none
+  #       value: 0.461
+
+  # - name: leaderboard_musr
+  #   metrics:
+  #     - name: acc-norm,none
+  #       value: 0.4435
+
+  # - name: leaderboard_mmlu_pro
+  #   metrics:
+  #     - name: acc,none
+  #       value: 0.5189
+
+  # - name: humaneval
+  #   metrics:
+  #     - name: exact_match,none
+  #       value: 0.832


### PR DESCRIPTION
SUMMARY:
adds task.yml config files for the models derived from meta-llama/Llama-3.1-8B-Instruct.
The task metric values are from the model card for the specific model (though the values for the "parent" come from the one of the RedHatAI models, where the evaluation accuracy table shows the measured parent metrics).

TEST PLAN:
I only ran a test for two of the models

this one failed with OOM for the server
* meta-llama/Llama-3.3-70B-Instruct [accuracy](https://github.com/neuralmagic/nm-cicd/actions/runs/14525284480)

this one seems to be running fine
* RedHatAI/Llama-3.3-70B-Instruct-quantized.w4a16 [accuracy](https://github.com/neuralmagic/nm-cicd/actions/runs/14525803198)