### PR TITLE
add tasks.yml for Qwen2.5-7B-Instruct models

### DIFF
--- a/Qwen/Qwen2.5-7B-Instruct/accuracy/tasks.yml
+++ b/Qwen/Qwen2.5-7B-Instruct/accuracy/tasks.yml
@@ -1,0 +1,31 @@
+tasks:
+  - name: arc_challenge
+    metrics:
+      - name: acc_norm,none
+        value: 0.5939
+
+  - name: gsm8k
+    metrics:
+      - name: strict_match,none
+        value: 0.7976
+
+  - name: hellaswag
+    metrics:
+      - name: acc_norm,none
+        value: 0.8017
+
+  - name: mmlu
+    metrics:
+      - name: acc,none
+        value: 0.7415
+
+  - name: truthfulqa_mc2
+    metrics:
+      - name: acc,none
+        value: 0.5637
+
+  - name: winogrande
+    metrics:
+      - name: acc,none
+        value: 0.7569
+

--- a/Qwen/Qwen2.5-7B-Instruct/accuracy/tasks.yml
+++ b/Qwen/Qwen2.5-7B-Instruct/accuracy/tasks.yml
@@ -6,7 +6,7 @@ tasks:
 
   - name: gsm8k
     metrics:
-      - name: strict_match,none
+      - name: exact_match,strict-match
         value: 0.7976
 
   - name: hellaswag

--- a/RedHatAI/Qwen2.5-7B-Instruct-FP8-dynamic/accuracy/tasks.yml
+++ b/RedHatAI/Qwen2.5-7B-Instruct-FP8-dynamic/accuracy/tasks.yml
@@ -1,0 +1,31 @@
+tasks:
+  - name: arc_challenge
+    metrics:
+      - name: acc_norm,none
+        value: 0.6314
+
+  - name: gsm8k
+    metrics:
+      - name: strict_match,none
+        value: 0.8006
+
+  - name: hellaswag
+    metrics:
+      - name: acc_norm,none
+        value: 0.8111
+
+  - name: mmlu
+    metrics:
+      - name: acc,none
+        value: 0.7404
+
+  - name: truthfulqa_mc2
+    metrics:
+      - name: acc,none
+        value: 0.6487
+
+  - name: winogrande
+    metrics:
+      - name: acc,none
+        value: 0.7443
+

--- a/RedHatAI/Qwen2.5-7B-Instruct-FP8-dynamic/accuracy/tasks.yml
+++ b/RedHatAI/Qwen2.5-7B-Instruct-FP8-dynamic/accuracy/tasks.yml
@@ -6,7 +6,7 @@ tasks:
 
   - name: gsm8k
     metrics:
-      - name: strict_match,none
+      - name: exact_match,strict-match
         value: 0.8006
 
   - name: hellaswag

--- a/RedHatAI/Qwen2.5-7B-Instruct-quantized.w4a16/accuracy/tasks.yml
+++ b/RedHatAI/Qwen2.5-7B-Instruct-quantized.w4a16/accuracy/tasks.yml
@@ -6,7 +6,7 @@ tasks:
 
   - name: gsm8k
     metrics:
-      - name: strict_match,none
+      - name: exact_match,strict-match
         value: 0.8059
 
   - name: hellaswag

--- a/RedHatAI/Qwen2.5-7B-Instruct-quantized.w4a16/accuracy/tasks.yml
+++ b/RedHatAI/Qwen2.5-7B-Instruct-quantized.w4a16/accuracy/tasks.yml
@@ -1,0 +1,31 @@
+tasks:
+  - name: arc_challenge
+    metrics:
+      - name: acc_norm,none
+        value: 0.6323
+
+  - name: gsm8k
+    metrics:
+      - name: strict_match,none
+        value: 0.8059
+
+  - name: hellaswag
+    metrics:
+      - name: acc_norm,none
+        value: 0.8065
+
+  - name: mmlu
+    metrics:
+      - name: acc,none
+        value: 0.7319
+
+  - name: truthfulqa_mc2
+    metrics:
+      - name: acc,none
+        value: 0.6427
+
+  - name: winogrande
+    metrics:
+      - name: acc,none
+        value: 0.7419
+

--- a/RedHatAI/Qwen2.5-7B-Instruct-quantized.w8a8/accuracy/tasks.yml
+++ b/RedHatAI/Qwen2.5-7B-Instruct-quantized.w8a8/accuracy/tasks.yml
@@ -1,0 +1,31 @@
+tasks:
+  - name: arc_challenge
+    metrics:
+      - name: acc_norm,none
+        value: 0.6323
+
+  - name: gsm8k
+    metrics:
+      - name: strict_match,none
+        value: 0.8074
+
+  - name: hellaswag
+    metrics:
+      - name: acc_norm,none
+        value: 0.8106
+
+  - name: mmlu
+    metrics:
+      - name: acc,none
+        value: 0.7387
+
+  - name: truthfulqa_mc2
+    metrics:
+      - name: acc,none
+        value: 0.6458
+
+  - name: winogrande
+    metrics:
+      - name: acc,none
+        value: 0.7482
+

--- a/RedHatAI/Qwen2.5-7B-Instruct-quantized.w8a8/accuracy/tasks.yml
+++ b/RedHatAI/Qwen2.5-7B-Instruct-quantized.w8a8/accuracy/tasks.yml
@@ -6,7 +6,7 @@ tasks:
 
   - name: gsm8k
     metrics:
-      - name: strict_match,none
+      - name: exact_match,strict-match
         value: 0.8074
 
   - name: hellaswag

--- a/RedHatAI/Qwen2.5-7B-quantized.w4a16/accuracy/tasks.yml
+++ b/RedHatAI/Qwen2.5-7B-quantized.w4a16/accuracy/tasks.yml
@@ -6,7 +6,7 @@ tasks:
 
   - name: gsm8k
     metrics:
-      - name: strict_match,none
+      - name: exact_match,strict-match
         value: 0.7908
 
   - name: hellaswag

--- a/RedHatAI/Qwen2.5-7B-quantized.w4a16/accuracy/tasks.yml
+++ b/RedHatAI/Qwen2.5-7B-quantized.w4a16/accuracy/tasks.yml
@@ -1,0 +1,31 @@
+tasks:
+  - name: arc_challenge
+    metrics:
+      - name: acc_norm,none
+        value: 0.587
+
+  - name: gsm8k
+    metrics:
+      - name: strict_match,none
+        value: 0.7908
+
+  - name: hellaswag
+    metrics:
+      - name: acc_norm,none
+        value: 0.7939
+
+  - name: mmlu
+    metrics:
+      - name: acc,none
+        value: 0.7347
+
+  - name: truthfulqa_mc2
+    metrics:
+      - name: acc,none
+        value: 0.5548
+
+  - name: winogrande
+    metrics:
+      - name: acc,none
+        value: 0.7601
+


### PR DESCRIPTION
SUMMARY:
adds task.yml config files for the models derived from Qwen/Qwen2.5-7B-Instruct.
The task metric values are from the model card for the specific model (though the values for the "parent" come from the one of the RedHatAI models, where the evaluation accuracy table shows the measured parent metrics).

TEST PLAN:
All runs are showing failures. these are likely due to the fact that either the server or client do not have configuration settings set exactly as described in the model card's evaluation section.

- Qwen/Qwen2.5-7B-Instruct [accuracy](https://github.com/neuralmagic/nm-cicd/actions/runs/14525696912)
- RedHatAI/Qwen2.5-7B-quantized.w4a16 [accuracy](https://github.com/neuralmagic/nm-cicd/actions/runs/14526802102)
- RedHatAI/Qwen2.5-7B-Instruct-quantized.w4a16 [accuracy](https://github.com/neuralmagic/nm-cicd/actions/runs/14526817821)
- RedHatAI/Qwen2.5-7B-Instruct-quantized.w8a8 [accuracy](https://github.com/neuralmagic/nm-cicd/actions/runs/14526833009)
- RedHatAI/Qwen2.5-7B-Instruct-FP8-dynamic [accuracy](https://github.com/neuralmagic/nm-cicd/actions/runs/14526843035)