### PR TITLE
add tasks.yml for mistralai/Mixtral-8x7B-Instruct-v0.1

### DIFF
--- a/mistralai/Mixtral-8x7B-Instruct-v0.1/accuracy/server.yml
+++ b/mistralai/Mixtral-8x7B-Instruct-v0.1/accuracy/server.yml
@@ -2,4 +2,4 @@
 model: "mistralai/Mixtral-8x7B-Instruct-v0.1"
 trust-remote-code: true
 add-bos-token: false
-tokenizer-mode: "mistral"
+enable_chunked_prefill: true

--- a/mistralai/Mixtral-8x7B-Instruct-v0.1/accuracy/tasks.yml
+++ b/mistralai/Mixtral-8x7B-Instruct-v0.1/accuracy/tasks.yml
@@ -6,7 +6,7 @@ tasks:
 
   - name: gsm8k
     metrics:
-      - name: strict_match,none
+      - name: exact_match,strict-match
         value: 0.655
 
   - name: hellaswag

--- a/mistralai/Mixtral-8x7B-Instruct-v0.1/accuracy/tasks.yml
+++ b/mistralai/Mixtral-8x7B-Instruct-v0.1/accuracy/tasks.yml
@@ -1,0 +1,31 @@
+tasks:
+  - name: arc_challenge
+    metrics:
+      - name: acc_norm,none
+        value: 0.7048
+
+  - name: gsm8k
+    metrics:
+      - name: strict_match,none
+        value: 0.655
+
+  - name: hellaswag
+    metrics:
+      - name: acc_norm,none
+        value: 0.8733
+
+  - name: mmlu
+    metrics:
+      - name: acc,none
+        value: 0.703
+
+  - name: truthfulqa_mc2
+    metrics:
+      - name: acc,none
+        value: 0.6481
+
+  - name: winogrande
+    metrics:
+      - name: acc,none
+        value: 0.8224
+


### PR DESCRIPTION
SUMMARY:
adds task.yml config files for the mistralai/Mixtral-8x7B-Instruct-v0.1.
The task metric values are from the model card for the specific model (though the values for the "parent" come from https://huggingface.co/RedHatAI/Mixtral-8x7B-Instruct-v0.1-FP8, where the evaluation accuracy table shows the measured parent metrics).

TEST PLAN:
I could not get the server to run w/ this model.  Here are two attempts:
* https://github.com/neuralmagic/nm-cicd/actions/runs/14527018633
* https://github.com/neuralmagic/nm-cicd/actions/runs/14527681249/job/40762153750
