### PR TITLE
Create common performance configs

### DIFF
--- a/common/performance/client.yml
+++ b/common/performance/client.yml
@@ -1,0 +1,12 @@
+data:
+  prompt_tokens: 512
+  prompt_tokens_stdev: 128
+  prompt_tokens_min: 1
+  prompt_tokens_max: 1024
+  output_tokens: 256
+  output_tokens_stdev: 64
+  output_tokens_min: 1
+  output_tokens_max: 1024
+rate-type: sweep
+max-seconds: 400
+warmup-percent: 0.2

--- a/common/performance/server.yml
+++ b/common/performance/server.yml
@@ -1,0 +1,5 @@
+uvicorn-log-level: "debug"
+trust-remote-code: true
+enable-chunked-prefill: true
+tensor-parallel-size: 1
+max-model-len: 4096


### PR DESCRIPTION
SUMMARY:
Add common performance configs for use when no model-specific configs exist. Support added in https://github.com/neuralmagic/nm-cicd/pull/66.

TEST PLAN:
Run where model-specific config exists: https://github.com/neuralmagic/nm-cicd/actions/runs/14537010137
Run where model-specific config does not exist: https://github.com/neuralmagic/nm-cicd/actions/runs/14537010283
