### PR TITLE
tasks.yml for Mistral-Small-3.1-24B-Instruct-2503

### DIFF
--- a/RedHatAI/Mistral-Small-3.1-24B-Instruct-2503-FP8-dynamic/accuracy/tasks.yml
+++ b/RedHatAI/Mistral-Small-3.1-24B-Instruct-2503-FP8-dynamic/accuracy/tasks.yml
@@ -2,32 +2,32 @@ tasks:
   - name: arc_challenge
     metrics:
       - name: acc_norm,none
-        value: 0.7278
+        value: 0.7287
 
   - name: gsm8k
     metrics:
       - name: strict_match,none
-        value: 0.6535
+        value: 0.6247
 
   - name: hellaswag
     metrics:
       - name: acc_norm,none
-        value: 0.837
+        value: 0.8467
 
   - name: mmlu
     metrics:
       - name: acc,none
-        value: 0.8067
+        value: 0.8071
 
   - name: truthfulqa_mc2
     metrics:
       - name: acc,none
-        value: 0.7062
+        value: 0.7088
 
   - name: winogrande
     metrics:
       - name: acc,none
-        value: 0.8374
+        value: 0.8256
 
   # following are placeholders for mid-level "leaderboard_*" tasks
   # (OpenLLM v2) waiting for info on how to calculate the metric
@@ -36,17 +36,17 @@ tasks:
   # - name: leaderboard_gpqa_main
   #   metrics:
   #     - name: acc-norm,none
-  #       value: 0.4263
+  #       value: 0.4107
 
   # - name: leaderboard_gpqa_diamond
   #   metrics:
   #     - name: acc-norm,none
-  #       value: 0.4596
+  #       value: 0.4545
 
   # - name: leaderboard_mmlu_pro
   #   metrics:
   #     - name: acc,none
-  #       value: 0.6725
+  #       value: 0.6686
 
   # - name: humaneval
   #   metrics:

--- a/RedHatAI/Mistral-Small-3.1-24B-Instruct-2503-quantized.w4a16/accuracy/tasks.yml
+++ b/RedHatAI/Mistral-Small-3.1-24B-Instruct-2503-quantized.w4a16/accuracy/tasks.yml
@@ -2,32 +2,32 @@ tasks:
   - name: arc_challenge
     metrics:
       - name: acc_norm,none
-        value: 0.7278
+        value: 0.7218
 
   - name: gsm8k
     metrics:
       - name: strict_match,none
-        value: 0.6535
+        value: 0.6634
 
   - name: hellaswag
     metrics:
       - name: acc_norm,none
-        value: 0.837
+        value: 0.8325
 
   - name: mmlu
     metrics:
       - name: acc,none
-        value: 0.8067
+        value: 0.7974
 
   - name: truthfulqa_mc2
     metrics:
       - name: acc,none
-        value: 0.7062
+        value: 0.6956
 
   - name: winogrande
     metrics:
       - name: acc,none
-        value: 0.8374
+        value: 0.8343
 
   # following are placeholders for mid-level "leaderboard_*" tasks
   # (OpenLLM v2) waiting for info on how to calculate the metric
@@ -36,19 +36,19 @@ tasks:
   # - name: leaderboard_gpqa_main
   #   metrics:
   #     - name: acc-norm,none
-  #       value: 0.4263
+  #       value: 0.471
 
   # - name: leaderboard_gpqa_diamond
   #   metrics:
   #     - name: acc-norm,none
-  #       value: 0.4596
+  #       value: 0.4495
 
   # - name: leaderboard_mmlu_pro
   #   metrics:
   #     - name: acc,none
-  #       value: 0.6725
+  #       value: 0.6656
 
   # - name: humaneval
   #   metrics:
   #     - name: exact_match,none
-  #       value: 0.847
+  #       value: 0.846

--- a/RedHatAI/Mistral-Small-3.1-24B-Instruct-2503-quantized.w8a8/accuracy/tasks.yml
+++ b/RedHatAI/Mistral-Small-3.1-24B-Instruct-2503-quantized.w8a8/accuracy/tasks.yml
@@ -2,32 +2,32 @@ tasks:
   - name: arc_challenge
     metrics:
       - name: acc_norm,none
-        value: 0.7278
+        value: 0.7346
 
   - name: gsm8k
     metrics:
       - name: strict_match,none
-        value: 0.6535
+        value: 0.7058
 
   - name: hellaswag
     metrics:
       - name: acc_norm,none
-        value: 0.837
+        value: 0.8226
 
   - name: mmlu
     metrics:
       - name: acc,none
-        value: 0.8067
+        value: 0.804
 
   - name: truthfulqa_mc2
     metrics:
       - name: acc,none
-        value: 0.7062
+        value: 0.6915
 
   - name: winogrande
     metrics:
       - name: acc,none
-        value: 0.8374
+        value: 0.809
 
   # following are placeholders for mid-level "leaderboard_*" tasks
   # (OpenLLM v2) waiting for info on how to calculate the metric
@@ -36,19 +36,19 @@ tasks:
   # - name: leaderboard_gpqa_main
   #   metrics:
   #     - name: acc-norm,none
-  #       value: 0.4263
+  #       value: 0.4464
 
   # - name: leaderboard_gpqa_diamond
   #   metrics:
   #     - name: acc-norm,none
-  #       value: 0.4596
+  #       value: 0.4192
 
   # - name: leaderboard_mmlu_pro
   #   metrics:
   #     - name: acc,none
-  #       value: 0.6725
+  #       value: 0.6654
 
   # - name: humaneval
   #   metrics:
   #     - name: exact_match,none
-  #       value: 0.847
+  #       value: 0.842


### PR DESCRIPTION
SUMMARY:
adds task.yml config files for the models derived from mistralai/Mistral-Small-3.1-24B-Instruct-2503.
The task metric values are from the model card for the specific model (though the values for the "parent" come from the one of the RedHatAI models, where the evaluation accuracy table shows the measured parent metrics).

TEST PLAN:
All runs are showing failures. these are likely due to the fact that either the server or client do not have configuration settings set exactly as described in the model card's evaluation section.

* mistralai/Mistral-Small-3.1-24B-Instruct-2503: [accuracy](https://github.com/neuralmagic/nm-cicd/actions/runs/14578686077)
* RedHatAI/Mistral-Small-3.1-24B-Instruct-2503-quantized.w8a8: [accuracy](https://github.com/neuralmagic/nm-cicd/actions/runs/14578471416)
* RedHatAI/Mistral-Small-3.1-24B-Instruct-2503-quantized.w4a16: [accuracy](https://github.com/neuralmagic/nm-cicd/actions/runs/14578442726)
* RedHatAI/Mistral-Small-3.1-24B-Instruct-2503-FP8-dynamic: [accuracy](https://github.com/neuralmagic/nm-cicd/actions/runs/14578429028)