### PR TITLE
adjust rtol on certain tasks for Qwen2.5 models to match measured

### DIFF
--- a/Qwen/Qwen2.5-7B-Instruct/accuracy/tasks.yml
+++ b/Qwen/Qwen2.5-7B-Instruct/accuracy/tasks.yml
@@ -1,5 +1,6 @@
 tasks:
   - name: arc_challenge
+    rtol: 0.09
     metrics:
       - name: acc_norm,none
         value: 0.5939
@@ -20,11 +21,13 @@ tasks:
         value: 0.7415
 
   - name: truthfulqa_mc2
+    rtol: 0.13
     metrics:
       - name: acc,none
         value: 0.5637
 
   - name: winogrande
+    rtol: 0.09
     metrics:
       - name: acc,none
         value: 0.7569

--- a/Qwen/Qwen2.5-7B-Instruct/accuracy/tasks.yml
+++ b/Qwen/Qwen2.5-7B-Instruct/accuracy/tasks.yml
@@ -6,6 +6,7 @@ tasks:
         value: 0.5939
 
   - name: gsm8k
+    rtol: 0.05
     metrics:
       - name: exact_match,strict-match
         value: 0.7976
@@ -21,7 +22,7 @@ tasks:
         value: 0.7415
 
   - name: truthfulqa_mc2
-    rtol: 0.13
+    rtol: 0.15
     metrics:
       - name: acc,none
         value: 0.5637

--- a/Qwen/Qwen2.5-7B-Instruct/accuracy/tasks.yml
+++ b/Qwen/Qwen2.5-7B-Instruct/accuracy/tasks.yml
@@ -3,33 +3,33 @@ tasks:
     rtol: 0.09
     metrics:
       - name: acc_norm,none
-        value: 0.5939
+        value: 0.634
 
   - name: gsm8k
     rtol: 0.05
     metrics:
       - name: exact_match,strict-match
-        value: 0.7976
+        value: 0.8036
 
   - name: hellaswag
     metrics:
       - name: acc_norm,none
-        value: 0.8017
+        value: 0.8152
 
   - name: mmlu
     metrics:
       - name: acc,none
-        value: 0.7415
+        value: 0.7424
 
   - name: truthfulqa_mc2
     rtol: 0.15
     metrics:
       - name: acc,none
-        value: 0.5637
+        value: 0.6476
 
   - name: winogrande
     rtol: 0.09
     metrics:
       - name: acc,none
-        value: 0.7569
+        value: 0.7466
 

--- a/RedHatAI/Qwen2.5-7B-Instruct-FP8-dynamic/accuracy/tasks.yml
+++ b/RedHatAI/Qwen2.5-7B-Instruct-FP8-dynamic/accuracy/tasks.yml
@@ -1,5 +1,6 @@
 tasks:
   - name: arc_challenge
+    rtol: 0.16
     metrics:
       - name: acc_norm,none
         value: 0.6314
@@ -25,6 +26,7 @@ tasks:
         value: 0.6487
 
   - name: winogrande
+    rtol: 0.07
     metrics:
       - name: acc,none
         value: 0.7443

--- a/RedHatAI/Qwen2.5-7B-Instruct-FP8-dynamic/accuracy/tasks.yml
+++ b/RedHatAI/Qwen2.5-7B-Instruct-FP8-dynamic/accuracy/tasks.yml
@@ -6,6 +6,7 @@ tasks:
         value: 0.6314
 
   - name: gsm8k
+    rtol: 0.06
     metrics:
       - name: exact_match,strict-match
         value: 0.8006

--- a/RedHatAI/Qwen2.5-7B-Instruct-quantized.w4a16/accuracy/tasks.yml
+++ b/RedHatAI/Qwen2.5-7B-Instruct-quantized.w4a16/accuracy/tasks.yml
@@ -1,11 +1,12 @@
 tasks:
   - name: arc_challenge
-    rtol: 0.13
+    rtol: 0.15
     metrics:
       - name: acc_norm,none
         value: 0.6323
 
   - name: gsm8k
+    rtol: 0.09
     metrics:
       - name: exact_match,strict-match
         value: 0.8059

--- a/RedHatAI/Qwen2.5-7B-Instruct-quantized.w4a16/accuracy/tasks.yml
+++ b/RedHatAI/Qwen2.5-7B-Instruct-quantized.w4a16/accuracy/tasks.yml
@@ -1,5 +1,6 @@
 tasks:
   - name: arc_challenge
+    rtol: 0.13
     metrics:
       - name: acc_norm,none
         value: 0.6323
@@ -25,6 +26,7 @@ tasks:
         value: 0.6427
 
   - name: winogrande
+    rtol: 0.07
     metrics:
       - name: acc,none
         value: 0.7419

--- a/RedHatAI/Qwen2.5-7B-Instruct-quantized.w8a8/accuracy/tasks.yml
+++ b/RedHatAI/Qwen2.5-7B-Instruct-quantized.w8a8/accuracy/tasks.yml
@@ -6,7 +6,7 @@ tasks:
         value: 0.6323
 
   - name: gsm8k
-    rtol: 0.07
+    rtol: 0.09
     metrics:
       - name: exact_match,strict-match
         value: 0.8074

--- a/RedHatAI/Qwen2.5-7B-Instruct-quantized.w8a8/accuracy/tasks.yml
+++ b/RedHatAI/Qwen2.5-7B-Instruct-quantized.w8a8/accuracy/tasks.yml
@@ -6,6 +6,7 @@ tasks:
         value: 0.6323
 
   - name: gsm8k
+    rtol: 0.07
     metrics:
       - name: exact_match,strict-match
         value: 0.8074

--- a/RedHatAI/Qwen2.5-7B-Instruct-quantized.w8a8/accuracy/tasks.yml
+++ b/RedHatAI/Qwen2.5-7B-Instruct-quantized.w8a8/accuracy/tasks.yml
@@ -1,5 +1,6 @@
 tasks:
   - name: arc_challenge
+    rtol: 0.21
     metrics:
       - name: acc_norm,none
         value: 0.6323
@@ -25,6 +26,7 @@ tasks:
         value: 0.6458
 
   - name: winogrande
+    rtol: 0.05
     metrics:
       - name: acc,none
         value: 0.7482

--- a/RedHatAI/Qwen2.5-7B-quantized.w4a16/accuracy/tasks.yml
+++ b/RedHatAI/Qwen2.5-7B-quantized.w4a16/accuracy/tasks.yml
@@ -1,6 +1,6 @@
 tasks:
   - name: arc_challenge
-    rtol: 0.16
+    rtol: 0.17
     metrics:
       - name: acc_norm,none
         value: 0.587

--- a/RedHatAI/Qwen2.5-7B-quantized.w4a16/accuracy/tasks.yml
+++ b/RedHatAI/Qwen2.5-7B-quantized.w4a16/accuracy/tasks.yml
@@ -1,5 +1,6 @@
 tasks:
   - name: arc_challenge
+    rtol: 0.16
     metrics:
       - name: acc_norm,none
         value: 0.587
@@ -25,6 +26,7 @@ tasks:
         value: 0.5548
 
   - name: winogrande
+    rtol: 0.09
     metrics:
       - name: acc,none
         value: 0.7601


### PR DESCRIPTION
SUMMARY:
adjust rtol on certain tasks to match measured.  research will need to review to approve the values.

TEST PLAN:
* Qwen/Qwen2.5-7B-Instruct: [accuracy](https://github.com/neuralmagic/nm-cicd/actions/runs/14631408549)
* RedHatAI/Qwen2.5-7B-Instruct-FP8-dynamic: [accuracy](https://github.com/neuralmagic/nm-cicd/actions/runs/14631429845)
* RedHatAI/Qwen2.5-7B-Instruct-quantized.w4a16: [accuracy](https://github.com/neuralmagic/nm-cicd/actions/runs/14631454227)
* RedHatAI/Qwen2.5-7B-Instruct-quantized.w8a8: [accuracy](https://github.com/neuralmagic/nm-cicd/actions/runs/14631473164)
* RedHatAI/Qwen2.5-7B-quantized.w4a16: [accuracy](https://github.com/neuralmagic/nm-cicd/actions/runs/14631495296)
