### PR TITLE
Provide common/accuracy/server.yml and remove phi-4/accuracy/server.yml

### DIFF
--- a/common/accuracy/server.yml
+++ b/common/accuracy/server.yml
@@ -1,4 +1,3 @@
 trust-remote-code: true
-enable-chunked-prefill: true
 tensor-parallel-size: 1
-max-model-len: 4096
+max-model-len: 16384

--- a/common/accuracy/server.yml
+++ b/common/accuracy/server.yml
@@ -1,5 +1,3 @@
-# server configs for https://huggingface.co/microsoft/phi-4
-model: "microsoft/phi-4"
 trust-remote-code: true
 enable-chunked-prefill: true
 tensor-parallel-size: 1


### PR DESCRIPTION
SUMMARY:
Provide common/accuracy/server.yml and remove phi-4/accuracy/server.yml.
The corresponding PR in nm-cicd has the code that uses the common server.yml when the model doesn't have one.

TEST PLAN:
both paths were tested...
Attempt with microsoft/phi-4 using common file: [accuracy](https://github.com/neuralmagic/nm-cicd/actions/runs/14671421077)
```
2025-04-25 18:49:31 - INFO - vllm_server_cm - starting server with command:
    vllm serve microsoft/phi-4 --config /home/runner/_work/nm-cicd/nm-cicd/model-validation-configs/common/accuracy/server.yml --port 8000
2025-04-25 18:49:31 - INFO - vllm_server_cm - config file contents (/home/runner/_work/nm-cicd/nm-cicd/model-validation-configs/common/accuracy/server.yml):
    enable-chunked-prefill: true
    max-model-len: 4096
    tensor-parallel-size: 1
    trust-remote-code: true
```

Attempt with Qwen/Qwen2.5-7B-Instruct using model’s file: [accuracy](https://github.com/neuralmagic/nm-cicd/actions/runs/14671488203)
```
2025-04-25 19:05:04 - INFO - vllm_server_cm - starting server with command:
    vllm serve Qwen/Qwen2.5-7B-Instruct --config /home/runner/_work/nm-cicd/nm-cicd/model-validation-configs/Qwen/Qwen2.5-7B-Instruct/accuracy/server.yml --port 8000
2025-04-25 19:05:04 - INFO - vllm_server_cm - config file contents (/home/runner/_work/nm-cicd/nm-cicd/model-validation-configs/Qwen/Qwen2.5-7B-Instruct/accuracy/server.yml):
    add-bos-token: false
    max-model-len: 8192
    tensor-parallel-size: 1
    trust-remote-code: true
```