### PR TITLE
remove add-bos-token from qwen2.5 model

### DIFF
--- a/Qwen/Qwen2.5-7B-Instruct/accuracy/server.yml
+++ b/Qwen/Qwen2.5-7B-Instruct/accuracy/server.yml
@@ -1,6 +1,5 @@
 # https://huggingface.co/Qwen/Qwen2.5-7B-Instruct
 model: "Qwen/Qwen2.5-7B-Instruct"
 trust-remote-code: true
-add-bos-token: false
 tensor-parallel-size: 1
 max-model-len: 8192


### PR DESCRIPTION
SUMMARY:
this model shouldn't have the add-bos-token server attribute set.

TEST PLAN:
test run demonstrates that it can run w/out that setting:
[model accuracy (Qwen/Qwen2.5-7B-Instruct, 14579564549)](https://github.com/neuralmagic/nm-cicd/actions/runs/14711307606/job/41284151724#logs)
```
2025-04-28 15:15:45 - INFO - vllm_server_cm - config file contents (/home/runner/_work/nm-cicd/nm-cicd/model-validation-configs/Qwen/Qwen2.5-7B-Instruct/accuracy/server.yml):
    max-model-len: 8192
    tensor-parallel-size: 1
    trust-remote-code: true
```
The run results fail because the comparison to ground truth fails.  This is resolved by a different PR.