### PR TITLE
phi-4 should not use apply-chat-template with llm-eval-harness

### DIFF
--- a/RedHatAI/phi-4-FP8-dynamic/accuracy/client.yml
+++ b/RedHatAI/phi-4-FP8-dynamic/accuracy/client.yml
@@ -1,4 +1,4 @@
 # llm-eval-test configs for https://huggingface.co/RedHatAI/phi-4-FP8-dynamic
 model: "RedHatAI/phi-4-FP8-dynamic"
-chat_template: true
+chat-template: false
 batch_size: "auto"

--- a/RedHatAI/phi-4-FP8-dynamic/accuracy/client.yml
+++ b/RedHatAI/phi-4-FP8-dynamic/accuracy/client.yml
@@ -1,4 +1,2 @@
 # llm-eval-test configs for https://huggingface.co/RedHatAI/phi-4-FP8-dynamic
 model: "RedHatAI/phi-4-FP8-dynamic"
-chat-template: false
-batch_size: "auto"

--- a/RedHatAI/phi-4-quantized.w4a16/accuracy/client.yml
+++ b/RedHatAI/phi-4-quantized.w4a16/accuracy/client.yml
@@ -1,4 +1,4 @@
 # llm-eval-test configs for https://huggingface.co/RedHatAI/phi-4-quantized.w4a16
 model: "RedHatAI/phi-4-quantized.w4a16"
-chat_template: true
+no-chat-template: false
 batch_size: "auto"

--- a/RedHatAI/phi-4-quantized.w4a16/accuracy/client.yml
+++ b/RedHatAI/phi-4-quantized.w4a16/accuracy/client.yml
@@ -1,4 +1,2 @@
 # llm-eval-test configs for https://huggingface.co/RedHatAI/phi-4-quantized.w4a16
 model: "RedHatAI/phi-4-quantized.w4a16"
-no-chat-template: false
-batch_size: "auto"

--- a/RedHatAI/phi-4-quantized.w8a8/accuracy/client.yml
+++ b/RedHatAI/phi-4-quantized.w8a8/accuracy/client.yml
@@ -1,4 +1,2 @@
 # llm-eval-test configs for https://huggingface.co/RedHatAI/phi-4-quantized.w8a8
 model: "RedHatAI/phi-4-quantized.w8a8"
-no-chat-template: true
-batch_size: "auto"

--- a/RedHatAI/phi-4-quantized.w8a8/accuracy/client.yml
+++ b/RedHatAI/phi-4-quantized.w8a8/accuracy/client.yml
@@ -1,4 +1,4 @@
 # llm-eval-test configs for https://huggingface.co/RedHatAI/phi-4-quantized.w8a8
 model: "RedHatAI/phi-4-quantized.w8a8"
-chat_template: true
+no_chat_template: true
 batch_size: "auto"

--- a/RedHatAI/phi-4-quantized.w8a8/accuracy/client.yml
+++ b/RedHatAI/phi-4-quantized.w8a8/accuracy/client.yml
@@ -1,4 +1,4 @@
 # llm-eval-test configs for https://huggingface.co/RedHatAI/phi-4-quantized.w8a8
 model: "RedHatAI/phi-4-quantized.w8a8"
-no_chat_template: true
+no-chat-template: true
 batch_size: "auto"

--- a/microsoft/phi-4/accuracy/client.yml
+++ b/microsoft/phi-4/accuracy/client.yml
@@ -1,3 +1,3 @@
 # llm-eval-test configs for https://huggingface.co/microsoft/phi-4
 model: "microsoft/phi-4"
-chat_template: true
+chat-template: true

--- a/microsoft/phi-4/accuracy/client.yml
+++ b/microsoft/phi-4/accuracy/client.yml
@@ -1,3 +1,2 @@
 # llm-eval-test configs for https://huggingface.co/microsoft/phi-4
 model: "microsoft/phi-4"
-chat-template: true


### PR DESCRIPTION
SUMMARY:
the model cards for the various RedHatAI/phi-4-* models indicate that to reproduce the reported data, the lm-eval command should not include the `apply-chat-template`.  Removed the `chat-template` option, and the "batch_size" option, from the client configurations for these models.

[@dagrayvid, I'm assuming that removing the option is equivalent to using `no-chat-template: true`]

TEST PLAN:
n/a