### PR TITLE
use a common/accuracy/client.yml configuration

### DIFF
--- a/Qwen/Qwen2.5-7B-Instruct/accuracy/client.yml
+++ b/Qwen/Qwen2.5-7B-Instruct/accuracy/client.yml
@@ -1,3 +1,0 @@
-# https://huggingface.co/Qwen/Qwen2.5-7B-Instruct
-model: "Qwen/Qwen2.5-7B-Instruct"
-chat_template: true

--- a/RedHatAI/Llama-3.3-70B-Instruct-FP8-dynamic/accuracy/client.yml
+++ b/RedHatAI/Llama-3.3-70B-Instruct-FP8-dynamic/accuracy/client.yml
@@ -1,4 +1,0 @@
-# llm-eval-test configs for https://huggingface.co/RedHatAI/Llama-3.3-70B-Instruct-FP8-dynamic
-model: "RedHatAI/Llama-3.3-70B-Instruct-FP8-dynamic"
-chat_template: true
-fewshot_as_multiturn: true

--- a/RedHatAI/Llama-3.3-70B-Instruct-quantized.w4a16/accuracy/client.yml
+++ b/RedHatAI/Llama-3.3-70B-Instruct-quantized.w4a16/accuracy/client.yml
@@ -1,5 +1,0 @@
-# llm-eval-test configs for https://huggingface.co/RedHatAI/Llama-3.3-70B-Instruct-quantized.w4a16
-model: "RedHatAI/Llama-3.3-70B-Instruct-quantized.w4a16"
-chat_template: true
-fewshot_as_multiturn: true
-num_fewshot: 5

--- a/RedHatAI/Llama-3.3-70B-Instruct-quantized.w8a8/accuracy/client.yml
+++ b/RedHatAI/Llama-3.3-70B-Instruct-quantized.w8a8/accuracy/client.yml
@@ -1,4 +1,0 @@
-# llm-eval-test configs for https://huggingface.co/RedHatAI/Llama-3.3-70B-Instruct-quantized.w8a8
-model: "RedHatAI/Llama-3.3-70B-Instruct-quantized.w8a8"
-chat_template: true
-fewshot_as_multiturn: true

--- a/RedHatAI/Llama-4-Scout-17B-16E-Instruct-FP8-dynamic/accuracy/client.yml
+++ b/RedHatAI/Llama-4-Scout-17B-16E-Instruct-FP8-dynamic/accuracy/client.yml
@@ -1,3 +1,0 @@
-# llm-eval-test configs for https://huggingface.co/RedHatAI/Llama-4-Scout-17B-16E-Instruct-FP8-dynamic
-model: "RedHatAI/Llama-4-Scout-17B-16E-Instruct-FP8-dynamic"
-chat_template: true

--- a/RedHatAI/Meta-Llama-3.1-8B-Instruct-FP8-dynamic/accuracy/client.yml
+++ b/RedHatAI/Meta-Llama-3.1-8B-Instruct-FP8-dynamic/accuracy/client.yml
@@ -1,4 +1,0 @@
-# llm-eval-test configs for https://huggingface.co/RedHatAI/Meta-Llama-3.1-8B-Instruct-FP8-dynamic
-model: "RedHatAI/Meta-Llama-3.1-8B-Instruct-FP8-dynamic"
-chat_template: true
-fewshot_as_multiturn: true

--- a/RedHatAI/Meta-Llama-3.1-8B-Instruct-quantized.w4a16/accuracy/client.yml
+++ b/RedHatAI/Meta-Llama-3.1-8B-Instruct-quantized.w4a16/accuracy/client.yml
@@ -1,4 +1,0 @@
-# llm-eval-test configs for https://huggingface.co/RedHatAI/Meta-Llama-3.1-8B-Instruct-quantized.w4a16
-model: "RedHatAI/Meta-Llama-3.1-8B-Instruct-quantized.w4a16"
-chat_template: true
-fewshot_as_multiturn: true

--- a/RedHatAI/Meta-Llama-3.1-8B-Instruct-quantized.w8a8/accuracy/client.yml
+++ b/RedHatAI/Meta-Llama-3.1-8B-Instruct-quantized.w8a8/accuracy/client.yml
@@ -1,4 +1,0 @@
-# llm-eval-test configs for https://huggingface.co/RedHatAI/Meta-Llama-3.1-8B-Instruct-quantized.w8a8
-model: "RedHatAI/Meta-Llama-3.1-8B-Instruct-quantized.w8a8"
-chat_template: true
-fewshot_as_multiturn: true

--- a/RedHatAI/Mistral-Small-24B-Instruct-2501-FP8-Dynamic/accuracy/client.yml
+++ b/RedHatAI/Mistral-Small-24B-Instruct-2501-FP8-Dynamic/accuracy/client.yml
@@ -1,4 +1,3 @@
 # llm-eval-test configs for https://huggingface.co/RedHatAI/Mistral-Small-24B-Instruct-2501-FP8-Dynamic
 model: "RedHatAI/Mistral-Small-24B-Instruct-2501-FP8-Dynamic"
-chat_template: true
-fewshot_as_multiturn: true
+no-chat-template: true

--- a/RedHatAI/Mistral-Small-24B-Instruct-2501-quantized.w4a16/accuracy/client.yml
+++ b/RedHatAI/Mistral-Small-24B-Instruct-2501-quantized.w4a16/accuracy/client.yml
@@ -1,4 +1,3 @@
 # llm-eval-test configs for https://huggingface.co/RedHatAI/Mistral-Small-24B-Instruct-2501-quantized.w4a16
 model: "RedHatAI/Mistral-Small-24B-Instruct-2501-quantized.w4a16"
-chat_template: true
-fewshot_as_multiturn: true
+no-chat-template: true

--- a/RedHatAI/Mistral-Small-24B-Instruct-2501-quantized.w8a8/accuracy/client.yml
+++ b/RedHatAI/Mistral-Small-24B-Instruct-2501-quantized.w8a8/accuracy/client.yml
@@ -1,3 +1,3 @@
 # llm-eval-test configs for https://huggingface.co/RedHatAI/Mistral-Small-24B-Instruct-2501-quantized.w8a8
 model: "RedHatAI/Mistral-Small-24B-Instruct-2501-quantized.w8a8"
-chat_template: true
+no-chat-template: true

--- a/RedHatAI/Mistral-Small-3.1-24B-Instruct-2503-FP8-dynamic/accuracy/client.yml
+++ b/RedHatAI/Mistral-Small-3.1-24B-Instruct-2503-FP8-dynamic/accuracy/client.yml
@@ -1,5 +1,0 @@
-# llm-eval-test configs for https://huggingface.co/RedHatAI/Mistral-Small-3.1-24B-Instruct-2503-FP8-dynamic
-model: "RedHatAI/Mistral-Small-3.1-24B-Instruct-2503-FP8-dynamic"
-chat_template: true
-fewshot_as_multiturn: true
-num_fewshot: 5

--- a/RedHatAI/Mistral-Small-3.1-24B-Instruct-2503-quantized.w4a16/accuracy/client.yml
+++ b/RedHatAI/Mistral-Small-3.1-24B-Instruct-2503-quantized.w4a16/accuracy/client.yml
@@ -1,5 +1,0 @@
-# llm-eval-test configs for https://huggingface.co/RedHatAI/Mistral-Small-3.1-24B-Instruct-2503-quantized.w4a16
-model: "RedHatAI/Mistral-Small-3.1-24B-Instruct-2503-quantized.w4a16"
-chat_template: true
-fewshot_as_multiturn: true
-num_fewshot: 5

--- a/RedHatAI/Mistral-Small-3.1-24B-Instruct-2503-quantized.w8a8/accuracy/client.yml
+++ b/RedHatAI/Mistral-Small-3.1-24B-Instruct-2503-quantized.w8a8/accuracy/client.yml
@@ -1,5 +1,0 @@
-# llm-eval-test configs for https://huggingface.co/RedHatAI/Mistral-Small-3.1-24B-Instruct-2503-quantized.w8a8
-model: "RedHatAI/Mistral-Small-3.1-24B-Instruct-2503-quantized.w8a8"
-chat_template: true
-fewshot_as_multiturn: true
-num_fewshot: 5

--- a/RedHatAI/Qwen2.5-7B-Instruct-FP8-dynamic/accuracy/client.yml
+++ b/RedHatAI/Qwen2.5-7B-Instruct-FP8-dynamic/accuracy/client.yml
@@ -1,4 +1,0 @@
-# llm-eval-test configs for https://huggingface.co/RedHatAI/Qwen2.5-7B-Instruct-FP8-dynamic
-model: "RedHatAI/Qwen2.5-7B-Instruct-FP8-dynamic"
-chat_template: true
-fewshot_as_multiturn: true

--- a/RedHatAI/Qwen2.5-7B-Instruct-quantized.w4a16/accuracy/client.yml
+++ b/RedHatAI/Qwen2.5-7B-Instruct-quantized.w4a16/accuracy/client.yml
@@ -1,4 +1,0 @@
-# https://huggingface.co/RedHatAI/Qwen2.5-7B-Instruct-quantized.w4a16
-model: "RedHatAI/Qwen2.5-7B-Instruct-quantized.w4a16"
-chat_template: true
-fewshot_as_multiturn: true

--- a/RedHatAI/Qwen2.5-7B-Instruct-quantized.w8a8/accuracy/client.yml
+++ b/RedHatAI/Qwen2.5-7B-Instruct-quantized.w8a8/accuracy/client.yml
@@ -1,4 +1,0 @@
-# llm-eval-test configs for https://huggingface.co/RedHatAI/Qwen2.5-7B-Instruct-quantized.w8a8
-model: "RedHatAI/Qwen2.5-7B-Instruct-quantized.w8a8"
-chat_template: true
-fewshot_as_multiturn: true

--- a/RedHatAI/Qwen2.5-7B-quantized.w4a16/accuracy/client.yml
+++ b/RedHatAI/Qwen2.5-7B-quantized.w4a16/accuracy/client.yml
@@ -1,3 +1,3 @@
 # llm-eval-test configs for https://huggingface.co/RedHatAI/Qwen2.5-7B-quantized.w4a16
 model: "RedHatAI/Qwen2.5-7B-quantized.w4a16"
-chat_template: true
+no-chat-template: true

--- a/RedHatAI/granite-3.1-8b-instruct-FP8-dynamic/accuracy/client.yml
+++ b/RedHatAI/granite-3.1-8b-instruct-FP8-dynamic/accuracy/client.yml
@@ -1,4 +1,3 @@
 # llm-eval-test configs for https://huggingface.co/RedHatAI/granite-3.1-8b-instruct-FP8-dynamic
 model: "RedHatAI/granite-3.1-8b-instruct-FP8-dynamic"
-chat_template: true
-batch_size: "auto"
+no-chat-template: true

--- a/RedHatAI/granite-3.1-8b-instruct-quantized.w4a16/accuracy/client.yml
+++ b/RedHatAI/granite-3.1-8b-instruct-quantized.w4a16/accuracy/client.yml
@@ -1,4 +1,3 @@
 # llm-eval-test configs for https://huggingface.co/RedHatAI/granite-3.1-8b-instruct-quantized.w4a16
 model: "RedHatAI/granite-3.1-8b-instruct-quantized.w4a16"
-chat_template: true
-batch_size: "auto"
+no-chat-template: true

--- a/RedHatAI/granite-3.1-8b-instruct-quantized.w8a8/accuracy/client.yml
+++ b/RedHatAI/granite-3.1-8b-instruct-quantized.w8a8/accuracy/client.yml
@@ -1,4 +1,3 @@
 # llm-eval-test configs for https://huggingface.co/RedHatAI/granite-3.1-8b-instruct-quantized.w8a8
 model: "RedHatAI/granite-3.1-8b-instruct-quantized.w8a8"
-chat_template: true
-batch_size: "auto"
+no-chat-template: true

--- a/RedHatAI/phi-4-FP8-dynamic/accuracy/client.yml
+++ b/RedHatAI/phi-4-FP8-dynamic/accuracy/client.yml
@@ -1,4 +1,3 @@
 # llm-eval-test configs for https://huggingface.co/RedHatAI/phi-4-FP8-dynamic
 model: "RedHatAI/phi-4-FP8-dynamic"
-chat_template: true
-batch_size: "auto"
+no-chat-template: true

--- a/RedHatAI/phi-4-quantized.w4a16/accuracy/client.yml
+++ b/RedHatAI/phi-4-quantized.w4a16/accuracy/client.yml
@@ -1,4 +1,3 @@
 # llm-eval-test configs for https://huggingface.co/RedHatAI/phi-4-quantized.w4a16
 model: "RedHatAI/phi-4-quantized.w4a16"
-chat_template: true
-batch_size: "auto"
+no-chat-template: true

--- a/RedHatAI/phi-4-quantized.w8a8/accuracy/client.yml
+++ b/RedHatAI/phi-4-quantized.w8a8/accuracy/client.yml
@@ -1,4 +1,3 @@
 # llm-eval-test configs for https://huggingface.co/RedHatAI/phi-4-quantized.w8a8
 model: "RedHatAI/phi-4-quantized.w8a8"
-chat_template: true
-batch_size: "auto"
+no-chat-template: true

--- a/common/accuracy/client.yml
+++ b/common/accuracy/client.yml
@@ -1,1 +1,1 @@
-chat_template: true
+chat-template: true

--- a/common/accuracy/client.yml
+++ b/common/accuracy/client.yml
@@ -1,0 +1,1 @@
+chat_template: true

--- a/ibm-granite/granite-3.1-8b-instruct/accuracy/client.yml
+++ b/ibm-granite/granite-3.1-8b-instruct/accuracy/client.yml
@@ -1,4 +1,3 @@
 # llm-eval-test configs for https://huggingface.co/ibm-granite/granite-3.1-8b-instruct
 model: "ibm-granite/granite-3.1-8b-instruct"
-chat_template: true
-fewshot_as_multiturn: true
+no-chat-template: true

--- a/meta-llama/Llama-3.1-8B-Instruct/accuracy/client.yml
+++ b/meta-llama/Llama-3.1-8B-Instruct/accuracy/client.yml
@@ -1,3 +1,0 @@
-# llm-eval-test configs for https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct
-model: "meta-llama/Llama-3.1-8B-Instruct"
-chat_template: true

--- a/meta-llama/Llama-3.3-70B-Instruct/accuracy/client.yml
+++ b/meta-llama/Llama-3.3-70B-Instruct/accuracy/client.yml
@@ -1,3 +1,0 @@
-# https://huggingface.co/meta-llama/Llama-3.3-70B-Instruct
-model: "meta-llama/Llama-3.3-70B-Instruct"
-chat_template: true

--- a/meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8/accuracy/client.yml
+++ b/meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8/accuracy/client.yml
@@ -1,3 +1,0 @@
-# llm-eval-test configs for https://huggingface.co/meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8
-model: "meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8"
-chat_template: true

--- a/meta-llama/Llama-4-Maverick-17B-128E-Instruct/accuracy/client.yml
+++ b/meta-llama/Llama-4-Maverick-17B-128E-Instruct/accuracy/client.yml
@@ -1,3 +1,0 @@
-# llm-eval-test configs for https://huggingface.co/meta-llama/Llama-4-Maverick-17B-128E-Instruct
-model: "meta-llama/Llama-4-Maverick-17B-128E-Instruct"
-chat_template: true

--- a/meta-llama/Llama-4-Scout-17B-16E-Instruct/accuracy/client.yml
+++ b/meta-llama/Llama-4-Scout-17B-16E-Instruct/accuracy/client.yml
@@ -1,3 +1,0 @@
-# llm-eval-test configs for https://huggingface.co/meta-llama/Llama-4-Scout-17B-16E-Instruct
-model: "meta-llama/Llama-4-Scout-17B-16E-Instruct"
-chat_template: true

--- a/microsoft/phi-4/accuracy/client.yml
+++ b/microsoft/phi-4/accuracy/client.yml
@@ -1,3 +1,3 @@
 # llm-eval-test configs for https://huggingface.co/microsoft/phi-4
 model: "microsoft/phi-4"
-chat_template: true
+no-chat-template: true

--- a/mistralai/Mistral-Small-24B-Instruct-2501/accuracy/client.yml
+++ b/mistralai/Mistral-Small-24B-Instruct-2501/accuracy/client.yml
@@ -1,3 +1,3 @@
 # llm-eval-test configs for https://huggingface.co/mistralai/Mistral-Small-24B-Instruct-2501
 model: "mistralai/Mistral-Small-24B-Instruct-2501"
-chat_template: true
+no-chat-template: true

--- a/mistralai/Mistral-Small-3.1-24B-Instruct-2503/accuracy/client.yml
+++ b/mistralai/Mistral-Small-3.1-24B-Instruct-2503/accuracy/client.yml
@@ -1,3 +1,0 @@
-# llm-eval-test configs for https://huggingface.co/mistralai/Mistral-Small-3.1-24B-Instruct-2503
-model: "mistralai/Mistral-Small-3.1-24B-Instruct-2503"
-chat_template: true

--- a/mistralai/Mixtral-8x7B-Instruct-v0.1/accuracy/client.yml
+++ b/mistralai/Mixtral-8x7B-Instruct-v0.1/accuracy/client.yml
@@ -1,3 +1,0 @@
-# https://huggingface.co/mistralai/Mixtral-8x7B-Instruct-v0.1
-model: "mistralai/Mixtral-8x7B-Instruct-v0.1"
-chat_template: true


### PR DESCRIPTION
SUMMARY:
many models use the same client.yml configuration, so just as with the server.yml file, we'll use a common/accuracy/client.yml for those models.  If a model requires something different, or in addition, it has it's own file.

This PR removes client.yml files where no longer needed, adds the common one, and updates those requiring different configuration.  

This PR goes along with the nm-cicd PR that updates the run_llm_eval_test.py script to use the common/accuracy/client.yml file and handles the `chat-template` and `no-chat-template` options.

TEST PLAN:
two runs were executed to demonstrate, first, when the custom client.yml file was used;
[accuracy](https://github.com/neuralmagic/nm-cicd/actions/runs/14742329575)
```
2025-04-29 22:29:06 - INFO - eval_accuracy - starting evaluation with command:
    llm-eval-test run --endpoint http://127.0.0.1:8000/v1/completions --model microsoft/phi-4 --tokenizer microsoft/phi-4 --datasets /home/runner/_work/nm-cicd/nm-cicd/datasets --tasks arc_challenge,gsm8k,hellaswag,mmlu,truthfulqa_mc2,winogrande --output microsoft_phi-4_eval_14742329575.json --no-chat-template
INFO 2025-04-29:22:29:06,220 [llm-eval-test@__main__.py:44] CLI called with {'catalog_path': '/home/runner/_work/nm-cicd/nm-cicd/.evalenv_14742329575/lib/python3.12/site-packages/llm_eval_test/benchmarks/catalog', 'tasks_path': '/home/runner/_work/nm-cicd/nm-cicd/.evalenv_14742329575/lib/python3.12/site-packages/llm_eval_test/benchmarks/tasks', 'offline': None, 'loglevel': 20, 'command': 'run', 'endpoint': 'http://127.0.0.1:8000/v1/completions', 'model': 'microsoft/phi-4', 'tasks': 'arc_challenge,gsm8k,hellaswag,mmlu,truthfulqa_mc2,winogrande', 'datasets': '/home/runner/_work/nm-cicd/nm-cicd/datasets', 'tokenizer': 'microsoft/phi-4', 'batch': 32, 'retry': 5, 'output': <_io.TextIOWrapper name='microsoft_phi-4_eval_14742329575.json' mode='w' encoding='UTF-8'>, 'format': <OutputFormat.summary: 'summary'>, 'chat_template': False}

```
and second, when the common client.yml file was used:
[accuracy](https://github.com/neuralmagic/nm-cicd/actions/runs/14742351533)
```
2025-04-30 00:02:54 - INFO - eval_accuracy - starting evaluation with command:
    llm-eval-test run --endpoint http://127.0.0.1:8000/v1/completions --model meta-llama/Llama-3.1-8B-Instruct --tokenizer meta-llama/Llama-3.1-8B-Instruct --datasets /home/runner/_work/nm-cicd/nm-cicd/datasets --tasks leaderboard_bbh,leaderboard_gpqa,leaderboard_ifeval,leaderboard_math_hard,leaderboard_musr --output meta-llama_Llama-3.1-8B-Instruct_eval_14742351533.json --chat-template
INFO 2025-04-30:00:02:54,365 [llm-eval-test@__main__.py:44] CLI called with {'catalog_path': '/home/runner/_work/nm-cicd/nm-cicd/.evalenv_14742351533/lib/python3.12/site-packages/llm_eval_test/benchmarks/catalog', 'tasks_path': '/home/runner/_work/nm-cicd/nm-cicd/.evalenv_14742351533/lib/python3.12/site-packages/llm_eval_test/benchmarks/tasks', 'offline': None, 'loglevel': 20, 'command': 'run', 'endpoint': 'http://127.0.0.1:8000/v1/completions', 'model': 'meta-llama/Llama-3.1-8B-Instruct', 'tasks': 'leaderboard_bbh,leaderboard_gpqa,leaderboard_ifeval,leaderboard_math_hard,leaderboard_musr', 'datasets': '/home/runner/_work/nm-cicd/nm-cicd/datasets', 'tokenizer': 'meta-llama/Llama-3.1-8B-Instruct', 'batch': 32, 'retry': 5, 'output': <_io.TextIOWrapper name='meta-llama_Llama-3.1-8B-Instruct_eval_14742351533.json' mode='w' encoding='UTF-8'>, 'format': <OutputFormat.summary: 'summary'>, 'chat_template': True}
```
