### PR TITLE
add tasks.yml and server.yml for Llama-4-Scout-17B-16E-Instruct models

### DIFF
--- a/RedHatAI/Llama-4-Scout-17B-16E-Instruct-FP8-dynamic/accuracy/server.yml
+++ b/RedHatAI/Llama-4-Scout-17B-16E-Instruct-FP8-dynamic/accuracy/server.yml
@@ -1,0 +1,4 @@
+trust-remote-code: true
+tensor-parallel-size: 8
+max-model-len: 16384
+gpu_memory_utilization: 0.7

--- a/RedHatAI/Llama-4-Scout-17B-16E-Instruct-FP8-dynamic/accuracy/tasks.yml
+++ b/RedHatAI/Llama-4-Scout-17B-16E-Instruct-FP8-dynamic/accuracy/tasks.yml
@@ -2,32 +2,32 @@ tasks:
   - name: arc_challenge
     metrics:
       - name: acc_norm,none
-        value: 0.6937
+        value: 0.6962
 
   - name: gsm8k
     metrics:
       - name: strict_match,none
-        value: 0.9045
+        value: 0.8976
 
   - name: hellaswag
     metrics:
       - name: acc_norm,none
-        value: 0.8523
+        value: 0.8518
 
   - name: mmlu
     metrics:
       - name: acc,none
-        value: 0.8054
+        value: 0.8049
 
   - name: truthfulqa_mc2
     metrics:
       - name: acc,none
-        value: 0.6141
+        value: 0.609
 
   - name: winogrande
     metrics:
       - name: acc,none
-        value: 0.779
+        value: 0.7703
 
   # following are placeholders for mid-level "leaderboard_*" tasks
   # (OpenLLM v2) waiting for info on how to calculate the metric
@@ -36,29 +36,29 @@ tasks:
   # - name: leaderboard_ifeval
   #   metrics:
   #     - name: inst_level_strict_acc,none
-  #       value: 0.869
+  #       value: 0.8769
 
   # - name: leaderboard_bbh
   #   metrics:
   #     - name: acc-norm,none
-  #       value: 0.6513
+  #       value: 0.6501
 
   # - name: leaderboard_math_hard
   #   metrics:
   #     - name: exact_match,none
-  #       value: 0.5778
+  #       value: 0.571
 
   # - name: leaderboard_gpqa
   #   metrics:
   #     - name: acc-norm,none
-  #       value: 0.3188
+  #       value: 0.3205
 
   # - name: leaderboard_musr
   #   metrics:
   #     - name: acc-norm,none
-  #       value: 0.422
+  #       value: 0.4312
 
   # - name: leaderboard_mmlu_pro
   #   metrics:
   #     - name: acc,none
-  #       value: 0.557
+  #       value: 0.556

--- a/RedHatAI/Llama-4-Scout-17B-16E-Instruct-quantized.w4a16/accuracy/server.yml
+++ b/RedHatAI/Llama-4-Scout-17B-16E-Instruct-quantized.w4a16/accuracy/server.yml
@@ -1,0 +1,4 @@
+trust-remote-code: true
+tensor-parallel-size: 8
+max-model-len: 16384
+gpu_memory_utilization: 0.7

--- a/RedHatAI/Llama-4-Scout-17B-16E-Instruct-quantized.w4a16/accuracy/tasks.yml
+++ b/RedHatAI/Llama-4-Scout-17B-16E-Instruct-quantized.w4a16/accuracy/tasks.yml
@@ -2,32 +2,32 @@ tasks:
   - name: arc_challenge
     metrics:
       - name: acc_norm,none
-        value: 0.6937
+        value: 0.6834
 
   - name: gsm8k
     metrics:
       - name: strict_match,none
-        value: 0.9045
+        value: 0.909
 
   - name: hellaswag
     metrics:
       - name: acc_norm,none
-        value: 0.8523
+        value: 0.8495
 
   - name: mmlu
     metrics:
       - name: acc,none
-        value: 0.8054
+        value: 0.8034
 
   - name: truthfulqa_mc2
     metrics:
       - name: acc,none
-        value: 0.6141
+        value: 0.613
 
   - name: winogrande
     metrics:
       - name: acc,none
-        value: 0.779
+        value: 0.7711
 
   # following are placeholders for mid-level "leaderboard_*" tasks
   # (OpenLLM v2) waiting for info on how to calculate the metric
@@ -36,17 +36,17 @@ tasks:
   # - name: leaderboard_ifeval
   #   metrics:
   #     - name: inst_level_strict_acc,none
-  #       value: 0.869
+  #       value: 0.8647
 
   # - name: leaderboard_bbh
   #   metrics:
   #     - name: acc-norm,none
-  #       value: 0.6513
+  #       value: 0.6478
 
   # - name: leaderboard_math_hard
   #   metrics:
   #     - name: exact_match,none
-  #       value: 0.5778
+  #       value: 0.5733
 
   # - name: leaderboard_gpqa
   #   metrics:
@@ -56,9 +56,10 @@ tasks:
   # - name: leaderboard_musr
   #   metrics:
   #     - name: acc-norm,none
-  #       value: 0.422
+  #       value: 0.4259
 
   # - name: leaderboard_mmlu_pro
   #   metrics:
   #     - name: acc,none
-  #       value: 0.557
+  #       value: 0.5496
+  

--- a/meta-llama/Llama-4-Scout-17B-16E-Instruct/accuracy/server.yml
+++ b/meta-llama/Llama-4-Scout-17B-16E-Instruct/accuracy/server.yml
@@ -1,0 +1,4 @@
+trust-remote-code: true
+tensor-parallel-size: 8
+max-model-len: 16384
+gpu_memory_utilization: 0.7


### PR DESCRIPTION
SUMMARY:
adds `task.yml` and `server.yml` config files for the models derived from meta-llama/Llama-4-Scout-17B-16E-Instruct.
The task metric values are from the model card for the specific model (though the values for the "parent" come from the one of the RedHatAI models, where the evaluation accuracy table shows the measured parent metrics).

TEST PLAN:

meta-llama/Llama-4-Scout-17B-16E-Instruct: 
RedHatAI/Llama-4-Scout-17B-16E-Instruct-FP8-dynamic: 