### PR TITLE
update server configs for large models

### DIFF
--- a/RedHatAI/Llama-4-Scout-17B-16E-Instruct-FP8-dynamic/accuracy/server.yml
+++ b/RedHatAI/Llama-4-Scout-17B-16E-Instruct-FP8-dynamic/accuracy/server.yml
@@ -1,3 +1,3 @@
 trust-remote-code: true
-tensor-parallel-size: 8
+tensor-parallel-size: 2
 max-model-len: 16384

--- a/RedHatAI/Llama-4-Scout-17B-16E-Instruct-quantized.w4a16/accuracy/server.yml
+++ b/RedHatAI/Llama-4-Scout-17B-16E-Instruct-quantized.w4a16/accuracy/server.yml
@@ -1,3 +1,3 @@
 trust-remote-code: true
-tensor-parallel-size: 8
+tensor-parallel-size: 2
 max-model-len: 16384

--- a/meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8/accuracy/server.yml
+++ b/meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8/accuracy/server.yml
@@ -1,3 +1,3 @@
 trust-remote-code: true
-tensor-parallel-size: 4
+tensor-parallel-size: 8
 max-model-len: 16384

--- a/meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8/accuracy/server.yml
+++ b/meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8/accuracy/server.yml
@@ -1,3 +1,3 @@
 trust-remote-code: true
-tensor-parallel-size: 8
+tensor-parallel-size: 4
 max-model-len: 16384

--- a/meta-llama/Llama-4-Scout-17B-16E-Instruct/accuracy/server.yml
+++ b/meta-llama/Llama-4-Scout-17B-16E-Instruct/accuracy/server.yml
@@ -1,3 +1,3 @@
 trust-remote-code: true
-tensor-parallel-size: 8
+tensor-parallel-size: 4
 max-model-len: 16384


### PR DESCRIPTION
SUMMARY:
Some large models cannot run using the common/accuracy/server.yml which sets tensor-parallel-size 1, updated the server configs which also matches with PSAP team's settings.

TEST PLAN:
manual tested
