### PR TITLE
accuracy base model tasks using summit data (INFERENG-586)

### DIFF
--- a/Qwen/Qwen2.5-7B-Instruct/accuracy/model_card_tasks.yml
+++ b/Qwen/Qwen2.5-7B-Instruct/accuracy/model_card_tasks.yml
@@ -1,0 +1,31 @@
+tasks:
+  - name: arc_challenge
+    metrics:
+      - name: acc_norm,none
+        value: 0.634
+
+  - name: gsm8k
+    metrics:
+      - name: exact_match,strict-match
+        value: 0.8036
+
+  - name: hellaswag
+    metrics:
+      - name: acc_norm,none
+        value: 0.8152
+
+  - name: mmlu
+    metrics:
+      - name: acc,none
+        value: 0.7424
+
+  - name: truthfulqa_mc2
+    metrics:
+      - name: acc,none
+        value: 0.6476
+
+  - name: winogrande
+    metrics:
+      - name: acc,none
+        value: 0.7466
+

--- a/Qwen/Qwen2.5-7B-Instruct/accuracy/model_card_tasks.yml
+++ b/Qwen/Qwen2.5-7B-Instruct/accuracy/model_card_tasks.yml
@@ -1,3 +1,4 @@
+# from RedHatAI/Qwen2.5-7B-Instruct-quantized.w4a16
 tasks:
   - name: arc_challenge
     metrics:
@@ -28,4 +29,3 @@ tasks:
     metrics:
       - name: acc,none
         value: 0.7466
-

--- a/Qwen/Qwen2.5-7B-Instruct/accuracy/tasks.yml
+++ b/Qwen/Qwen2.5-7B-Instruct/accuracy/tasks.yml
@@ -3,55 +3,55 @@ tasks:
   - name: arc_challenge
     metrics:
       - name: acc_norm,none
-        value: 0.634
+        value: 0.6689
 
   - name: gsm8k
     metrics:
       - name: exact_match,strict-match
-        value: 0.8036
+        value: 0.7634
 
   - name: hellaswag
     metrics:
       - name: acc_norm,none
-        value: 0.8152
+        value: 0.8150
 
   - name: mmlu
     metrics:
       - name: acc,none
-        value: 0.7424
+        value: 0.7430
 
   - name: truthfulqa_mc2
     metrics:
       - name: acc,none
-        value: 0.6476
+        value: 0.6479
 
   - name: winogrande
     metrics:
       - name: acc,none
-        value: 0.7466
+        value: 0.7419
 
   - name: leaderboard_ifeval
     metrics:
       - name: inst_level_strict_acc,none
-        value: 0.0587
+        value: 0.6906
 
   - name: leaderboard_gpqa_diamond
     metrics:
       - name: acc-norm,none
-        value: 0.3939
+        value: 0.3484
 
   - name: leaderboard_gpqa_extended
     metrics:
       - name: acc-norm,none
-        value: 0.3882
+        value: 0.3095
 
   - name: leaderboard_gpqa_main
     metrics:
       - name: acc-norm,none
-        value: 0.4129
+        value: 0.3191
 
   - name: leaderboard_mmlu_pro
     metrics:
       - name: acc,none
-        value: 0.53
+        value: 0.4472
   

--- a/Qwen/Qwen2.5-7B-Instruct/accuracy/tasks.yml
+++ b/Qwen/Qwen2.5-7B-Instruct/accuracy/tasks.yml
@@ -1,3 +1,4 @@
+# from gs://nm-vllm-certs/model-validation/lmeval/Qwen/Qwen2.5-7B-Instruct/cuda/0.8.4.post1/k8s-a100-duo/llm_eval_14786279345.json
 tasks:
   - name: arc_challenge
     metrics:
@@ -29,3 +30,28 @@ tasks:
       - name: acc,none
         value: 0.7466
 
+  - name: leaderboard_ifeval
+    metrics:
+      - name: inst_level_strict_acc,none
+        value: 0.0587
+
+  - name: leaderboard_gpqa_diamond
+    metrics:
+      - name: acc-norm,none
+        value: 0.3939
+
+  - name: leaderboard_gpqa_extended
+    metrics:
+      - name: acc-norm,none
+        value: 0.3882
+
+  - name: leaderboard_gpqa_main
+    metrics:
+      - name: acc-norm,none
+        value: 0.4129
+
+  - name: leaderboard_mmlu_pro
+    metrics:
+      - name: acc,none
+        value: 0.53
+  

--- a/Qwen/Qwen2.5-7B-Instruct/accuracy/tasks.yml
+++ b/Qwen/Qwen2.5-7B-Instruct/accuracy/tasks.yml
@@ -54,4 +54,3 @@ tasks:
     metrics:
       - name: acc,none
         value: 0.4472
-  

--- a/Qwen/Qwen2.5-7B-Instruct/accuracy/tasks.yml
+++ b/Qwen/Qwen2.5-7B-Instruct/accuracy/tasks.yml
@@ -2,30 +2,30 @@ tasks:
   - name: arc_challenge
     metrics:
       - name: acc_norm,none
-        value: 0.5939
+        value: 0.634
 
   - name: gsm8k
     metrics:
       - name: exact_match,strict-match
-        value: 0.7976
+        value: 0.8036
 
   - name: hellaswag
     metrics:
       - name: acc_norm,none
-        value: 0.8017
+        value: 0.8152
 
   - name: mmlu
     metrics:
       - name: acc,none
-        value: 0.7415
+        value: 0.7424
 
   - name: truthfulqa_mc2
     metrics:
       - name: acc,none
-        value: 0.5637
+        value: 0.6476
 
   - name: winogrande
     metrics:
       - name: acc,none
-        value: 0.7569
+        value: 0.7466
 

--- a/Qwen/Qwen2.5-7B/accuracy/model_card_tasks.yml
+++ b/Qwen/Qwen2.5-7B/accuracy/model_card_tasks.yml
@@ -1,0 +1,31 @@
+# from https://huggingface.co/RedHatAI/Qwen2.5-7B-quantized.w4a16
+tasks:
+  - name: arc_challenge
+    metrics:
+      - name: acc_norm,none
+        value: 0.5939
+
+  - name: gsm8k
+    metrics:
+      - name: exact_match,strict-match
+        value: 0.7976
+
+  - name: hellaswag
+    metrics:
+      - name: acc_norm,none
+        value: 0.8017
+
+  - name: mmlu
+    metrics:
+      - name: acc,none
+        value: 0.7415
+
+  - name: truthfulqa_mc2
+    metrics:
+      - name: acc,none
+        value: 0.5638
+
+  - name: winogrande
+    metrics:
+      - name: acc,none
+        value: 0.7569

--- a/Qwen/Qwen2.5-7B/accuracy/tasks.yml
+++ b/Qwen/Qwen2.5-7B/accuracy/tasks.yml
@@ -1,0 +1,31 @@
+# from 
+tasks:
+  - name: arc_challenge
+    metrics:
+      - name: acc_norm,none
+        value: 0.5939
+
+  - name: gsm8k
+    metrics:
+      - name: exact_match,strict-match
+        value: 0.7976
+
+  - name: hellaswag
+    metrics:
+      - name: acc_norm,none
+        value: 0.8017
+
+  - name: mmlu
+    metrics:
+      - name: acc,none
+        value: 0.7415
+
+  - name: truthfulqa_mc2
+    metrics:
+      - name: acc,none
+        value: 0.5638
+
+  - name: winogrande
+    metrics:
+      - name: acc,none
+        value: 0.7569

--- a/Qwen/Qwen2.5-7B/accuracy/tasks.yml
+++ b/Qwen/Qwen2.5-7B/accuracy/tasks.yml
@@ -1,31 +1,31 @@
-# from 
+# from gs://nm-vllm-certs/model-validation/lmeval/Qwen/Qwen2.5-7B/cuda/0.9.1.dev238+g922878ced/k8s-a100-duo/llm_eval_16218386266.json
 tasks:
   - name: arc_challenge
     metrics:
       - name: acc_norm,none
-        value: 0.5939
+        value: 0.6373
 
   - name: gsm8k
     metrics:
       - name: exact_match,strict-match
-        value: 0.7976
+        value: 0.8074
 
   - name: hellaswag
     metrics:
       - name: acc_norm,none
-        value: 0.8017
+        value: 0.8024
 
   - name: mmlu
     metrics:
       - name: acc,none
-        value: 0.7415
+        value: 0.7424
 
   - name: truthfulqa_mc2
     metrics:
       - name: acc,none
-        value: 0.5638
+        value: 0.5633
 
   - name: winogrande
     metrics:
       - name: acc,none
-        value: 0.7569
+        value: 0.7505

--- a/Qwen/Qwen2.5-7B/storage.yml
+++ b/Qwen/Qwen2.5-7B/storage.yml
@@ -1,0 +1,3 @@
+# https://huggingface.co/Qwen/Qwen2.5-7B
+model: hf
+data: hf

--- a/common/accuracy/server.yml
+++ b/common/accuracy/server.yml
@@ -1,3 +1,3 @@
-# trust-remote-code: true
+trust-remote-code: true
 tensor-parallel-size: 1
 max-model-len: 16384

--- a/common/accuracy/server.yml
+++ b/common/accuracy/server.yml
@@ -1,3 +1,3 @@
-trust-remote-code: true
+# trust-remote-code: true
 tensor-parallel-size: 1
 max-model-len: 16384

--- a/ibm-granite/granite-3.1-8b-instruct/accuracy/model_card_tasks.yml
+++ b/ibm-granite/granite-3.1-8b-instruct/accuracy/model_card_tasks.yml
@@ -1,0 +1,66 @@
+tasks:
+  - name: arc_challenge
+    metrics:
+      - name: acc_norm,none
+        value: 0.6681
+
+  - name: gsm8k
+    metrics:
+      - name: exact_match,strict-match
+        value: 0.6452
+
+  - name: hellaswag
+    metrics:
+      - name: acc_norm,none
+        value: 0.8418
+
+  - name: mmlu
+    metrics:
+      - name: acc,none
+        value: 0.6552
+
+  - name: truthfulqa_mc2
+    metrics:
+      - name: acc,none
+        value: 0.6057
+
+  - name: winogrande
+    metrics:
+      - name: acc,none
+        value: 0.8019
+
+  - name: leaderboard_ifeval
+    metrics:
+      - name: inst_level_strict_acc,none
+        value: 0.7401
+
+  - name: leaderboard_bbh
+    metrics:
+      - name: acc-norm,none
+        value: 0.5319
+
+  - name: leaderboard_math_hard
+    metrics:
+      - name: exact_match,none
+        value: 0.1477
+
+  - name: leaderboard_gpqa
+    metrics:
+      - name: acc-norm,none
+        value: 0.3176
+
+  - name: leaderboard_musr
+    metrics:
+      - name: acc-norm,none
+        value: 0.4601
+
+  - name: leaderboard_mmlu_pro
+    metrics:
+      - name: acc,none
+        value: 0.3581
+
+  # - name: humaneval
+  #   metrics:
+  #     - name: exact_match,none
+  #       value: 0.71
+  

--- a/ibm-granite/granite-3.1-8b-instruct/accuracy/model_card_tasks.yml
+++ b/ibm-granite/granite-3.1-8b-instruct/accuracy/model_card_tasks.yml
@@ -1,3 +1,4 @@
+# from RedHatAI/granite-3.1-8b-instruct-quantized.w8a8
 tasks:
   - name: arc_challenge
     metrics:
@@ -63,4 +64,3 @@ tasks:
   #   metrics:
   #     - name: exact_match,none
   #       value: 0.71
-  

--- a/ibm-granite/granite-3.1-8b-instruct/accuracy/tasks.yml
+++ b/ibm-granite/granite-3.1-8b-instruct/accuracy/tasks.yml
@@ -31,39 +31,35 @@ tasks:
       - name: acc,none
         value: 0.8019
 
-  # following are placeholders for mid-level "leaderboard_*" tasks
-  # (OpenLLM v2) waiting for info on how to calculate the metric
-  # values from the individual sub tasks.
+  - name: leaderboard_ifeval
+    metrics:
+      - name: inst_level_strict_acc,none
+        value: 0.7401
 
-  # - name: leaderboard_ifeval
-  #   metrics:
-  #     - name: inst_level_strict_acc,none
-  #       value: 0.741
+  - name: leaderboard_bbh
+    metrics:
+      - name: acc-norm,none
+        value: 0.5319
 
-  # - name: leaderboard_bbh
-  #   metrics:
-  #     - name: acc-norm,none
-  #       value: 0.5319
+  - name: leaderboard_math_hard
+    metrics:
+      - name: exact_match,none
+        value: 0.1477
 
-  # - name: leaderboard_math_hard
-  #   metrics:
-  #     - name: exact_match,none
-  #       value: 0.1477
+  - name: leaderboard_gpqa
+    metrics:
+      - name: acc-norm,none
+        value: 0.3176
 
-  # - name: leaderboard_gpqa
-  #   metrics:
-  #     - name: acc-norm,none
-  #       value: 0.3176
+  - name: leaderboard_musr
+    metrics:
+      - name: acc-norm,none
+        value: 0.4601
 
-  # - name: leaderboard_musr
-  #   metrics:
-  #     - name: acc-norm,none
-  #       value: 0.4601
-
-  # - name: leaderboard_mmlu_pro
-  #   metrics:
-  #     - name: acc,none
-  #       value: 0.3581
+  - name: leaderboard_mmlu_pro
+    metrics:
+      - name: acc,none
+        value: 0.3581
 
   # - name: humaneval
   #   metrics:

--- a/ibm-granite/granite-3.1-8b-instruct/accuracy/tasks.yml
+++ b/ibm-granite/granite-3.1-8b-instruct/accuracy/tasks.yml
@@ -1,66 +1,62 @@
+# from gs://nm-vllm-certs/model-validation/lmeval/ibm-granite/granite-3.1-8b-instruct/cuda/0.8.4.post1/k8s-a100-duo/llm_eval_14786366303.json
 tasks:
   - name: arc_challenge
     metrics:
       - name: acc_norm,none
-        value: 0.6681
+        value: 0.6663
 
   - name: gsm8k
     metrics:
       - name: exact_match,strict-match
-        value: 0.6452
+        value: 0.6376
 
   - name: hellaswag
     metrics:
       - name: acc_norm,none
-        value: 0.8418
+        value: 0.8412
 
   - name: mmlu
     metrics:
       - name: acc,none
-        value: 0.6552
+        value: 0.656
 
   - name: truthfulqa_mc2
     metrics:
       - name: acc,none
-        value: 0.6057
+        value: 0.6048
 
   - name: winogrande
     metrics:
       - name: acc,none
-        value: 0.8019
+        value: 0.7987
 
   - name: leaderboard_ifeval
     metrics:
       - name: inst_level_strict_acc,none
-        value: 0.7401
+        value: 0.6666
 
-  - name: leaderboard_bbh
-    metrics:
-      - name: acc-norm,none
-        value: 0.5319
+  # - name: leaderboard_bbh
+  #   metrics:
+  #     - name: acc-norm,none
+  #       value: 0.5319
 
-  - name: leaderboard_math_hard
-    metrics:
-      - name: exact_match,none
-        value: 0.1477
+  # - name: leaderboard_math_hard
+  #   metrics:
+  #     - name: exact_match,none
+  #       value: 0.1477
 
-  - name: leaderboard_gpqa
-    metrics:
-      - name: acc-norm,none
-        value: 0.3176
+  # - name: leaderboard_gpqa
+  #   metrics:
+  #     - name: acc-norm,none
+  #       value: 0.3176
 
-  - name: leaderboard_musr
-    metrics:
-      - name: acc-norm,none
-        value: 0.4601
+  # - name: leaderboard_musr
+  #   metrics:
+  #     - name: acc-norm,none
+  #       value: 0.4601
 
   - name: leaderboard_mmlu_pro
     metrics:
       - name: acc,none
-        value: 0.3581
-
-  # - name: humaneval
-  #   metrics:
-  #     - name: exact_match,none
-  #       value: 0.71
+        value: 0.3517
   

--- a/ibm-granite/granite-3.1-8b-instruct/accuracy/tasks.yml
+++ b/ibm-granite/granite-3.1-8b-instruct/accuracy/tasks.yml
@@ -1,6 +1,5 @@
 tasks:
   - name: arc_challenge
-    rtol: 0.24
     metrics:
       - name: acc_norm,none
         value: 0.6681
@@ -26,7 +25,6 @@ tasks:
         value: 0.6057
 
   - name: winogrande
-    rtol: 0.07
     metrics:
       - name: acc,none
         value: 0.8019

--- a/ibm-granite/granite-3.1-8b-instruct/accuracy/tasks.yml
+++ b/ibm-granite/granite-3.1-8b-instruct/accuracy/tasks.yml
@@ -59,4 +59,3 @@ tasks:
     metrics:
       - name: acc,none
         value: 0.3517
-  

--- a/ibm-granite/granite-3.1-8b-instruct/accuracy/tasks.yml
+++ b/ibm-granite/granite-3.1-8b-instruct/accuracy/tasks.yml
@@ -1,0 +1,72 @@
+tasks:
+  - name: arc_challenge
+    rtol: 0.24
+    metrics:
+      - name: acc_norm,none
+        value: 0.6681
+
+  - name: gsm8k
+    metrics:
+      - name: exact_match,strict-match
+        value: 0.6452
+
+  - name: hellaswag
+    metrics:
+      - name: acc_norm,none
+        value: 0.8418
+
+  - name: mmlu
+    metrics:
+      - name: acc,none
+        value: 0.6552
+
+  - name: truthfulqa_mc2
+    metrics:
+      - name: acc,none
+        value: 0.6057
+
+  - name: winogrande
+    rtol: 0.07
+    metrics:
+      - name: acc,none
+        value: 0.8019
+
+  # following are placeholders for mid-level "leaderboard_*" tasks
+  # (OpenLLM v2) waiting for info on how to calculate the metric
+  # values from the individual sub tasks.
+
+  # - name: leaderboard_ifeval
+  #   metrics:
+  #     - name: inst_level_strict_acc,none
+  #       value: 0.741
+
+  # - name: leaderboard_bbh
+  #   metrics:
+  #     - name: acc-norm,none
+  #       value: 0.5319
+
+  # - name: leaderboard_math_hard
+  #   metrics:
+  #     - name: exact_match,none
+  #       value: 0.1477
+
+  # - name: leaderboard_gpqa
+  #   metrics:
+  #     - name: acc-norm,none
+  #       value: 0.3176
+
+  # - name: leaderboard_musr
+  #   metrics:
+  #     - name: acc-norm,none
+  #       value: 0.4601
+
+  # - name: leaderboard_mmlu_pro
+  #   metrics:
+  #     - name: acc,none
+  #       value: 0.3581
+
+  # - name: humaneval
+  #   metrics:
+  #     - name: exact_match,none
+  #       value: 0.71
+  

--- a/meta-llama/Llama-3.1-8B-Instruct/accuracy/model_card_tasks.yml
+++ b/meta-llama/Llama-3.1-8B-Instruct/accuracy/model_card_tasks.yml
@@ -1,68 +1,66 @@
-# from gs://nm-vllm-certs/model-validation/lmeval/meta-llama/Llama-3.1-8B-Instruct/cuda/0.8.4.post1/k8s-a100-duo/llm_eval_14826550740.json
 tasks:
   - name: arc_challenge
     metrics:
       - name: acc_norm,none
-        value: 0.6049
+        value: 0.814
 
   - name: gsm8k
     metrics:
       - name: exact_match,strict-match
-        value: 0.7657
+        value: 0.828
 
   - name: hellaswag
     metrics:
       - name: acc_norm,none
-        value: 0.8023
+        value: 0.805
 
   - name: mmlu
     metrics:
       - name: acc,none
-        value: 0.682
+        value: 0.683
 
   - name: truthfulqa_mc2
     metrics:
       - name: acc,none
-        value: 0.5406
+        value: 0.545
 
   - name: winogrande
     metrics:
       - name: acc,none
-        value: 0.7726
+        value: 0.781
 
   - name: leaderboard_ifeval
     metrics:
       - name: inst_level_strict_acc,none
-        value: 0.5683
+        value: 0.779
 
-  # - name: leaderboard_bbh
-  #   metrics:
-  #     - name: acc-norm,none
-  #       value: 0.301
-
-  # - name: leaderboard_math_hard
-  #   metrics:
-  #     - name: exact_match,none
-  #       value: 0.3254
-
-  - name: leaderboard_gpqa_diamond
+  - name: leaderboard_bbh
     metrics:
       - name: acc-norm,none
-        value: 0.3282
+        value: 0.301
 
-  - name: leaderboard_gpqa_extended
+  - name: leaderboard_math_hard
+    metrics:
+      - name: exact_match,none
+        value: 0.157
+
+  - name: leaderboard_gpqa
     metrics:
       - name: acc-norm,none
-        value: 0.2857
+        value: 0.37
 
-  # averaged
   - name: leaderboard_musr
     metrics:
       - name: acc-norm,none
-        value: 0.4025
+        value: 0.76
 
   - name: leaderboard_mmlu_pro
     metrics:
       - name: acc,none
-        value: 0.3789
+        value: 0.308
+
+  # - name: humaneval
+  #   metrics:
+  #     - name: exact_match,none
+  #       value: 0.71
   

--- a/meta-llama/Llama-3.1-8B-Instruct/accuracy/model_card_tasks.yml
+++ b/meta-llama/Llama-3.1-8B-Instruct/accuracy/model_card_tasks.yml
@@ -1,3 +1,4 @@
+# from RedHatAI/Meta-Llama-3.1-8B-Instruct-FP8-dynamic
 tasks:
   - name: arc_challenge
     metrics:
@@ -63,4 +64,3 @@ tasks:
   #   metrics:
   #     - name: exact_match,none
   #       value: 0.71
-  

--- a/meta-llama/Llama-3.1-8B-Instruct/accuracy/tasks.yml
+++ b/meta-llama/Llama-3.1-8B-Instruct/accuracy/tasks.yml
@@ -1,28 +1,66 @@
-# accuracy configs for https://huggingface.co/meta-llama/Meta-Llama-3.1-8B-Instruct
 tasks:
-- name: "leaderboard_bbh"
-  metrics:
-  - name: "acc_norm,none"
-    value: 0.50946
-- name: "leaderboard_gpqa"
-  metrics:
-  - name: "acc_norm,none"
-    value: 0.29698
-- name: "leaderboard_ifeval"
-  metrics:
-  - name: "inst_level_loose_acc,none"
-    value: 0.85851
-  - name: "inst_level_strict_acc,none"
-    value: 0.82374
-  - name: "prompt_level_loose_acc,none"
-    value: 0.79667
-  - name: "prompt_level_strict_acc,none"
-    value: 0.74861
-- name: "leaderboard_math_hard"
-  metrics:
-  - name: "exact_match,none"
-    value: 0.19864
-- name: "leaderboard_musr"
-  metrics:
-  - name: "acc_norm,none"
-    value: 0.38359
+  - name: arc_challenge
+    metrics:
+      - name: acc_norm,none
+        value: 0.814
+
+  - name: gsm8k
+    metrics:
+      - name: exact_match,strict-match
+        value: 0.828
+
+  - name: hellaswag
+    metrics:
+      - name: acc_norm,none
+        value: 0.805
+
+  - name: mmlu
+    metrics:
+      - name: acc,none
+        value: 0.683
+
+  - name: truthfulqa_mc2
+    metrics:
+      - name: acc,none
+        value: 0.545
+
+  - name: winogrande
+    metrics:
+      - name: acc,none
+        value: 0.781
+
+  - name: leaderboard_ifeval
+    metrics:
+      - name: inst_level_strict_acc,none
+        value: 0.779
+
+  - name: leaderboard_bbh
+    metrics:
+      - name: acc-norm,none
+        value: 0.301
+
+  - name: leaderboard_math_hard
+    metrics:
+      - name: exact_match,none
+        value: 0.157
+
+  - name: leaderboard_gpqa
+    metrics:
+      - name: acc-norm,none
+        value: 0.37
+
+  - name: leaderboard_musr
+    metrics:
+      - name: acc-norm,none
+        value: 0.76
+
+  - name: leaderboard_mmlu_pro
+    metrics:
+      - name: acc,none
+        value: 0.308
+
+  # - name: humaneval
+  #   metrics:
+  #     - name: exact_match,none
+  #       value: 0.71
+  

--- a/meta-llama/Llama-3.1-8B-Instruct/accuracy/tasks.yml
+++ b/meta-llama/Llama-3.1-8B-Instruct/accuracy/tasks.yml
@@ -65,4 +65,3 @@ tasks:
     metrics:
       - name: acc,none
         value: 0.3789
-  

--- a/meta-llama/Llama-3.3-70B-Instruct/accuracy/model_card_tasks.yml
+++ b/meta-llama/Llama-3.3-70B-Instruct/accuracy/model_card_tasks.yml
@@ -1,0 +1,61 @@
+# from RedHatAI/Llama-3.3-70B-Instruct-quantized.w8a8
+tasks:
+  - name: arc_challenge
+    metrics:
+      - name: acc_norm,none
+        value: 0.4923
+
+  - name: gsm8k
+    metrics:
+      - name: exact_match,strict-match
+        value: 0.9416
+
+  - name: hellaswag
+    metrics:
+      - name: acc_norm,none
+        value: 0.8649
+
+  - name: mmlu
+    metrics:
+      - name: acc,none
+        value: 0.816
+
+  - name: truthfulqa_mc2
+    metrics:
+      - name: acc,none
+        value: 0.6275
+
+  - name: winogrande
+    metrics:
+      - name: acc,none
+        value: 0.8477
+
+  - name: leaderboard_ifeval
+    metrics:
+      - name: inst_level_strict_acc,none
+        value: 0.9089
+
+  - name: leaderboard_bbh
+    metrics:
+      - name: acc-norm,none
+        value: 0.6315
+
+  - name: leaderboard_math_v_5
+    metrics:
+      - name: exact_match,none
+        value: 0.0017
+
+  - name: leaderboard_gpqa
+    metrics:
+      - name: acc-norm,none
+        value: 0.461
+
+  - name: leaderboard_musr
+    metrics:
+      - name: acc-norm,none
+        value: 0.4435
+
+  - name: leaderboard_mmlu_pro
+    metrics:
+      - name: acc,none
+        value: 0.5189

--- a/meta-llama/Llama-3.3-70B-Instruct/accuracy/tasks.yml
+++ b/meta-llama/Llama-3.3-70B-Instruct/accuracy/tasks.yml
@@ -1,3 +1,4 @@
+# from gs://nm-vllm-certs/model-validation/lmeval/meta-llama/Llama-3.3-70B-Instruct/cuda/0.8.4.post1/gpu19-h100-octo/llm_eval_0.json
 tasks:
   - name: arc_challenge
     metrics:

--- a/meta-llama/Llama-3.3-70B-Instruct/accuracy/tasks.yml
+++ b/meta-llama/Llama-3.3-70B-Instruct/accuracy/tasks.yml
@@ -2,41 +2,37 @@ tasks:
   - name: arc_challenge
     metrics:
       - name: acc_norm,none
-        value: 0.4923
+        value: 0.7201
 
   - name: gsm8k
     metrics:
       - name: exact_match,strict-match
-        value: 0.9416
+        value: 0.9082
 
   - name: hellaswag
     metrics:
       - name: acc_norm,none
-        value: 0.8649
+        value: 0.8642
 
   - name: mmlu
     metrics:
       - name: acc,none
-        value: 0.816
+        value: 0.8223
 
   - name: truthfulqa_mc2
     metrics:
       - name: acc,none
-        value: 0.6275
+        value: 0.6097
 
   - name: winogrande
     metrics:
       - name: acc,none
-        value: 0.8477
+        value: 0.8397
 
-  # following are placeholders for mid-level "leaderboard_*" tasks
-  # (OpenLLM v2) waiting for info on how to calculate the metric
-  # values from the individual sub tasks.
-
-  # - name: leaderboard_ifeval
-  #   metrics:
-  #     - name: inst_level_strict_acc,none
-  #       value: 0.9089
+  - name: leaderboard_ifeval
+    metrics:
+      - name: inst_level_strict_acc,none
+        value: 0.723
 
   # - name: leaderboard_bbh
   #   metrics:
@@ -59,12 +55,7 @@ tasks:
   #     - name: acc-norm,none
   #       value: 0.4435
 
-  # - name: leaderboard_mmlu_pro
-  #   metrics:
-  #     - name: acc,none
-  #       value: 0.5189
-
-  # - name: humaneval
-  #   metrics:
-  #     - name: exact_match,none
-  #       value: 0.832
+  - name: leaderboard_mmlu_pro
+    metrics:
+      - name: acc,none
+        value: 0.5495

--- a/meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8/accuracy/tasks.yml
+++ b/meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8/accuracy/tasks.yml
@@ -1,28 +1,60 @@
-# accuracy configs for https://huggingface.co/meta-llama/Meta-Llama-3.1-8B-Instruct
 tasks:
-- name: "leaderboard_bbh"
-  metrics:
-  - name: "acc_norm,none"
-    value: 0.50946
-- name: "leaderboard_gpqa"
-  metrics:
-  - name: "acc_norm,none"
-    value: 0.29698
-- name: "leaderboard_ifeval"
-  metrics:
-  - name: "inst_level_loose_acc,none"
-    value: 0.85851
-  - name: "inst_level_strict_acc,none"
-    value: 0.82374
-  - name: "prompt_level_loose_acc,none"
-    value: 0.79667
-  - name: "prompt_level_strict_acc,none"
-    value: 0.74861
-- name: "leaderboard_math_hard"
-  metrics:
-  - name: "exact_match,none"
-    value: 0.19864
-- name: "leaderboard_musr"
-  metrics:
-  - name: "acc_norm,none"
-    value: 0.38359
+  - name: arc_challenge
+    metrics:
+      - name: acc_norm,none
+        value: 0.7363
+
+  - name: gsm8k
+    metrics:
+      - name: exact_match,strict-match
+        value: 0.9302
+
+  - name: hellaswag
+    metrics:
+      - name: acc_norm,none
+        value: 0.8742
+
+  - name: mmlu
+    metrics:
+      - name: acc,none
+        value: 0.861
+
+  - name: truthfulqa_mc2
+    metrics:
+      - name: acc,none
+        value: 0.6015
+
+  - name: winogrande
+    metrics:
+      - name: acc,none
+        value: 0.8082
+
+  - name: leaderboard_ifeval
+    metrics:
+      - name: inst_level_strict_acc,none
+        value: 0.7446
+
+  # - name: leaderboard_bbh
+  #   metrics:
+  #     - name: acc-norm,none
+  #       value: 0.6315
+
+  # - name: leaderboard_math_v_5
+  #   metrics:
+  #     - name: exact_match,none
+  #       value: 0.0017
+
+  # - name: leaderboard_gpqa
+  #   metrics:
+  #     - name: acc-norm,none
+  #       value: 0.461
+
+  # - name: leaderboard_musr
+  #   metrics:
+  #     - name: acc-norm,none
+  #       value: 0.4435
+
+  - name: leaderboard_mmlu_pro
+    metrics:
+      - name: acc,none
+        value: 0.6479

--- a/meta-llama/Llama-4-Scout-17B-16E-Instruct/accuracy/model_card_tasks.yml
+++ b/meta-llama/Llama-4-Scout-17B-16E-Instruct/accuracy/model_card_tasks.yml
@@ -1,4 +1,4 @@
-# from https://huggingface.co/RedHatAI/Llama-4-Scout-17B-16E-Instruct-FP8-dynamic
+# from RedHatAI/Llama-4-Scout-17B-16E-Instruct-FP8-dynamic
 tasks:
   - name: arc_challenge
     metrics:
@@ -59,4 +59,3 @@ tasks:
     metrics:
       - name: acc,none
         value: 0.557
-  

--- a/meta-llama/Llama-4-Scout-17B-16E-Instruct/accuracy/model_card_tasks.yml
+++ b/meta-llama/Llama-4-Scout-17B-16E-Instruct/accuracy/model_card_tasks.yml
@@ -1,61 +1,62 @@
+# from https://huggingface.co/RedHatAI/Llama-4-Scout-17B-16E-Instruct-FP8-dynamic
 tasks:
   - name: arc_challenge
     metrics:
       - name: acc_norm,none
-        value: 0.6936
+        value: 0.6937
 
   - name: gsm8k
     metrics:
       - name: exact_match,strict-match
-        value: 0.9044
+        value: 0.9045
 
   - name: hellaswag
     metrics:
       - name: acc_norm,none
-        value: 0.8514
+        value: 0.8523
 
   - name: mmlu
     metrics:
       - name: acc,none
-        value: 0.8042
+        value: 0.8054
 
   - name: truthfulqa_mc2
     metrics:
       - name: acc,none
-        value: 0.5975
+        value: 0.6141
 
   - name: winogrande
     metrics:
       - name: acc,none
-        value: 0.7861
+        value: 0.7790
 
   - name: leaderboard_ifeval
     metrics:
       - name: inst_level_strict_acc,none
-        value: 0.7889
+        value: 0.8690
 
   # - name: leaderboard_bbh
   #   metrics:
   #     - name: acc-norm,none
-  #       value: 0.5319
+  #       value: 0.6513
 
   # - name: leaderboard_math_hard
   #   metrics:
   #     - name: exact_match,none
-  #       value: 0.1477
+  #       value: 0.5778
 
   # - name: leaderboard_gpqa
   #   metrics:
   #     - name: acc-norm,none
-  #       value: 0.3176
+  #       value: 0.3188
 
   # - name: leaderboard_musr
   #   metrics:
   #     - name: acc-norm,none
-  #       value: 0.4601
+  #       value: 0.422
 
   - name: leaderboard_mmlu_pro
     metrics:
       - name: acc,none
-        value: 0.5554
+        value: 0.557
   

--- a/meta-llama/Llama-4-Scout-17B-16E-Instruct/accuracy/tasks.yml
+++ b/meta-llama/Llama-4-Scout-17B-16E-Instruct/accuracy/tasks.yml
@@ -1,3 +1,4 @@
+# from gs://nm-vllm-certs/model-validation/lmeval/meta-llama/Llama-4-Scout-17B-16E-Instruct/cuda/0.8.4.post1/gpu19-h100-octo/llm_eval_0.json
 tasks:
   - name: arc_challenge
     metrics:
@@ -58,4 +59,3 @@ tasks:
     metrics:
       - name: acc,none
         value: 0.5554
-  

--- a/microsoft/phi-4/accuracy/model_card_tasks.yml
+++ b/microsoft/phi-4/accuracy/model_card_tasks.yml
@@ -1,0 +1,30 @@
+tasks:
+  - name: arc_challenge
+    metrics:
+      - name: acc_norm,none
+        value: 0.6442
+
+  - name: gsm8k
+    metrics:
+      - name: exact_match,strict-match
+        value: 0.9007
+
+  - name: hellaswag
+    metrics:
+      - name: acc_norm,none
+        value: 0.8437
+
+  - name: mmlu
+    metrics:
+      - name: acc,none
+        value: 0.803
+
+  - name: truthfulqa_mc2
+    metrics:
+      - name: acc,none
+        value: 0.5937
+
+  - name: winogrande
+    metrics:
+      - name: acc,none
+        value: 0.8058

--- a/microsoft/phi-4/accuracy/model_card_tasks.yml
+++ b/microsoft/phi-4/accuracy/model_card_tasks.yml
@@ -1,3 +1,4 @@
+# from RedHatAI/phi-4-quantized.w8a8
 tasks:
   - name: arc_challenge
     metrics:

--- a/microsoft/phi-4/accuracy/tasks.yml
+++ b/microsoft/phi-4/accuracy/tasks.yml
@@ -1,18 +1,19 @@
+# from gs://nm-vllm-certs/model-validation/lmeval/microsoft/phi-4/cuda/0.8.4.post1/k8s-a100-duo/llm_eval_14786302755.json
 tasks:
   - name: arc_challenge
     metrics:
       - name: acc_norm,none
-        value: 0.6442
+        value: 0.6825
 
   - name: gsm8k
     metrics:
       - name: exact_match,strict-match
-        value: 0.9007
+        value: 0.8999
 
   - name: hellaswag
     metrics:
       - name: acc_norm,none
-        value: 0.8437
+        value: 0.8435
 
   - name: mmlu
     metrics:
@@ -22,9 +23,35 @@ tasks:
   - name: truthfulqa_mc2
     metrics:
       - name: acc,none
-        value: 0.5937
+        value: 0.5934
 
   - name: winogrande
     metrics:
       - name: acc,none
-        value: 0.8058
+        value: 0.8011
+
+  - name: leaderboard_ifeval
+    metrics:
+      - name: inst_level_strict_acc,none
+        value: 0.0587
+
+  - name: leaderboard_gpqa_diamond
+    metrics:
+      - name: acc-norm,none
+        value: 0.3939
+
+  - name: leaderboard_gpqa_extended
+    metrics:
+      - name: acc-norm,none
+        value: 0.3882
+
+  - name: leaderboard_gpqa_main
+    metrics:
+      - name: acc-norm,none
+        value: 0.4129
+
+  - name: leaderboard_mmlu_pro
+    metrics:
+      - name: acc,none
+        value: 0.53
+  

--- a/microsoft/phi-4/accuracy/tasks.yml
+++ b/microsoft/phi-4/accuracy/tasks.yml
@@ -54,4 +54,3 @@ tasks:
     metrics:
       - name: acc,none
         value: 0.53
-  

--- a/mistralai/Mistral-Small-24B-Instruct-2501/accuracy/model_card_tasks.yml
+++ b/mistralai/Mistral-Small-24B-Instruct-2501/accuracy/model_card_tasks.yml
@@ -1,45 +1,51 @@
-# from gs://nm-vllm-certs/model-validation/lmeval/mistralai/Mistral-Small-24B-Instruct-2501/cuda/0.8.4.post1/k8s-a100-duo/llm_eval_14786286971.json
 tasks:
   - name: arc_challenge
     metrics:
       - name: acc_norm,none
-        value: 0.7244
+        value: 0.7218
 
   - name: gsm8k
     metrics:
       - name: exact_match,strict-match
-        value: 0.8953
+        value: 0.9014
 
   - name: hellaswag
     metrics:
       - name: acc_norm,none
-        value: 0.8487
+        value: 0.8505
 
   - name: mmlu
     metrics:
       - name: acc,none
-        value: 0.8037
+        value: 0.8069
 
   - name: truthfulqa_mc2
     metrics:
       - name: acc,none
-        value: 0.6494
+        value: 0.6555
 
   - name: winogrande
     metrics:
       - name: acc,none
-        value: 0.8184
+        value: 0.8311
 
   - name: leaderboard_ifeval
     metrics:
       - name: inst_level_strict_acc,none
-        value: 0.6882
+        value: 0.7327
 
-  # - name: leaderboard_bbh
-  #   metrics:
-  #     - name: acc-norm,none
-  #       value: 0.4518
+  - name: leaderboard_bbh
+    metrics:
+      - name: acc-norm,none
+        value: 0.4518
 
+  - name: leaderboard_mmlu_pro
+    metrics:
+      - name: acc,none
+        value: 0.3883
+  
+  # ignored because quantized.w4a16 model card indicates these
+  # aren't considered viable for recovery calculation
   # - name: leaderboard_gpqa
   #   metrics:
   #     - name: acc-norm,none
@@ -49,9 +55,3 @@ tasks:
   #   metrics:
   #     - name: acc-norm,none
   #       value: 0.784
-
-  - name: leaderboard_mmlu_pro
-    metrics:
-      - name: acc,none
-        value: 0.5389
-  

--- a/mistralai/Mistral-Small-24B-Instruct-2501/accuracy/model_card_tasks.yml
+++ b/mistralai/Mistral-Small-24B-Instruct-2501/accuracy/model_card_tasks.yml
@@ -1,3 +1,4 @@
+# from RedHatAI/Mistral-Small-24B-Instruct-2501-quantized.w4a16
 tasks:
   - name: arc_challenge
     metrics:

--- a/mistralai/Mistral-Small-24B-Instruct-2501/accuracy/tasks.yml
+++ b/mistralai/Mistral-Small-24B-Instruct-2501/accuracy/tasks.yml
@@ -1,197 +1,56 @@
-# collected vllm v0.8.3.post1 on k8s-a100-duo
 tasks:
-  - name: leaderboard_math_algebra_hard
-    metrics:
-      - name: exact_match,none
-        value: 0.703
-
-  - name: leaderboard_math_counting_and_prob_hard
-    metrics:
-      - name: exact_match,none
-        value: 0.489
-
-  - name: leaderboard_math_geometry_hard
-    metrics:
-      - name: exact_match,none
-        value: 0.366
-
-  - name: leaderboard_math_intermediate_algebra_hard
-    metrics:
-      - name: exact_match,none
-        value: 0.283
-
-  - name: leaderboard_math_num_theory_hard
-    metrics:
-      - name: exact_match,none
-        value: 0.476
-
-  - name: leaderboard_math_prealgebra_hard
-    metrics:
-      - name: exact_match,none
-        value: 0.695
-
-  - name: leaderboard_math_precalculus_hard
-    metrics:
-      - name: exact_match,none
-        value: 0.355
-
-  - name: leaderboard_bbh_boolean_expressions
+  - name: arc_challenge
     metrics:
       - name: acc_norm,none
-        value: 0.876
+        value: 0.7218
 
-  - name: leaderboard_bbh_causal_judgement
+  - name: gsm8k
+    metrics:
+      - name: exact_match,strict-match
+        value: 0.9014
+
+  - name: hellaswag
     metrics:
       - name: acc_norm,none
-        value: 0.652
+        value: 0.8505
 
-  - name: leaderboard_bbh_date_understanding
+  - name: mmlu
     metrics:
-      - name: acc_norm,none
-        value: 0.796
+      - name: acc,none
+        value: 0.8069
 
-  - name: leaderboard_bbh_disambiguation_qa
+  - name: truthfulqa_mc2
     metrics:
-      - name: acc_norm,none
-        value: 0.696
+      - name: acc,none
+        value: 0.6555
 
-  - name: leaderboard_bbh_formal_fallacies
+  - name: winogrande
     metrics:
-      - name: acc_norm,none
-        value: 0.684
-
-  - name: leaderboard_bbh_geometric_shapes
-    metrics:
-      - name: acc_norm,none
-        value: 0.508
-
-  - name: leaderboard_bbh_hyperbaton
-    metrics:
-      - name: acc_norm,none
-        value: 0.78
-
-  - name: leaderboard_bbh_logical_deduction_five_objects
-    metrics:
-      - name: acc_norm,none
-        value: 0.632
-
-  - name: leaderboard_bbh_logical_deduction_seven_objects
-    metrics:
-      - name: acc_norm,none
-        value: 0.636
-
-  - name: leaderboard_bbh_logical_deduction_three_objects
-    metrics:
-      - name: acc_norm,none
-        value: 0.876
-
-  - name: leaderboard_bbh_movie_recommendation
-    metrics:
-      - name: acc_norm,none
-        value: 0.848
-
-  - name: leaderboard_bbh_navigate
-    metrics:
-      - name: acc_norm,none
-        value: 0.688
-
-  - name: leaderboard_bbh_object_counting
-    metrics:
-      - name: acc_norm,none
-        value: 0.42
-
-  - name: leaderboard_bbh_penguins_in_a_table
-    metrics:
-      - name: acc_norm,none
-        value: 0.767
-
-  - name: leaderboard_bbh_reasoning_about_colored_objects
-    metrics:
-      - name: acc_norm,none
-        value: 0.764
-
-  - name: leaderboard_bbh_ruin_names
-    metrics:
-      - name: acc_norm,none
-        value: 0.868
-
-  - name: leaderboard_bbh_salient_translation_error_detection
-    metrics:
-      - name: acc_norm,none
-        value: 0.684
-
-  - name: leaderboard_bbh_snarks
-    metrics:
-      - name: acc_norm,none
-        value: 0.725
-
-  - name: leaderboard_bbh_sports_understanding
-    metrics:
-      - name: acc_norm,none
-        value: 0.836
-
-  - name: leaderboard_bbh_temporal_sequences
-    metrics:
-      - name: acc_norm,none
-        value: 0.984
-
-  - name: leaderboard_bbh_tracking_shuffled_objects_five_objects
-    metrics:
-      - name: acc_norm,none
-        value: 0.288
-
-  - name: leaderboard_bbh_tracking_shuffled_objects_seven_objects
-    metrics:
-      - name: acc_norm,none
-        value: 0.224
-
-  - name: leaderboard_bbh_tracking_shuffled_objects_three_objects
-    metrics:
-      - name: acc_norm,none
-        value: 0.348
-
-  - name: leaderboard_bbh_web_of_lies
-    metrics:
-      - name: acc_norm,none
-        value: 0.52
-
-  - name: leaderboard_gpqa_diamond
-    metrics:
-      - name: acc_norm,none
-        value: 0.399
-
-  - name: leaderboard_gpqa_extended
-    metrics:
-      - name: acc_norm,none
-        value: 0.405
-
-  - name: leaderboard_gpqa_main
-    metrics:
-      - name: acc_norm,none
-        value: 0.393
-
-  - name: leaderboard_musr_murder_mysteries
-    metrics:
-      - name: acc_norm,none
-        value: 0.556
-
-  - name: leaderboard_musr_object_placements
-    metrics:
-      - name: acc_norm,none
-        value: 0.437
-
-  - name: leaderboard_musr_team_allocation
-    metrics:
-      - name: acc_norm,none
-        value: 0.404
+      - name: acc,none
+        value: 0.8311
 
   - name: leaderboard_ifeval
     metrics:
-      - name: prompt_level_strict_acc,none
-        value: 0.582
-      - name: prompt_level_loose_acc,none
-        value: 0.647
-      - name: inst_level_loose_acc,none
-        value: 0.748
       - name: inst_level_strict_acc,none
-        value: 0.693
+        value: 0.7327
+
+  - name: leaderboard_bbh
+    metrics:
+      - name: acc-norm,none
+        value: 0.4518
+
+  - name: leaderboard_gpqa
+    metrics:
+      - name: acc-norm,none
+        value: 0.829
+
+  - name: leaderboard_musr
+    metrics:
+      - name: acc-norm,none
+        value: 0.784
+
+  - name: leaderboard_mmlu_pro
+    metrics:
+      - name: acc,none
+        value: 0.3883
+  

--- a/mistralai/Mistral-Small-24B-Instruct-2501/accuracy/tasks.yml
+++ b/mistralai/Mistral-Small-24B-Instruct-2501/accuracy/tasks.yml
@@ -54,4 +54,3 @@ tasks:
     metrics:
       - name: acc,none
         value: 0.5389
-  

--- a/mistralai/Mistral-Small-3.1-24B-Instruct-2503/accuracy/model_card_tasks.yml
+++ b/mistralai/Mistral-Small-3.1-24B-Instruct-2503/accuracy/model_card_tasks.yml
@@ -1,0 +1,30 @@
+tasks:
+  - name: arc_challenge
+    metrics:
+      - name: acc_norm,none
+        value: 0.7278
+
+  - name: gsm8k
+    metrics:
+      - name: exact_match,strict-match
+        value: 0.5668
+
+  - name: hellaswag
+    metrics:
+      - name: acc_norm,none
+        value: 0.8370
+
+  - name: mmlu
+    metrics:
+      - name: acc,none
+        value: 0.8067
+
+  - name: truthfulqa_mc2
+    metrics:
+      - name: acc,none
+        value: 0.7062
+
+  - name: winogrande
+    metrics:
+      - name: acc,none
+        value: 0.8374

--- a/mistralai/Mistral-Small-3.1-24B-Instruct-2503/accuracy/model_card_tasks.yml
+++ b/mistralai/Mistral-Small-3.1-24B-Instruct-2503/accuracy/model_card_tasks.yml
@@ -1,3 +1,4 @@
+# from RedHatAI/Mistral-Small-3.1-24B-Instruct-2503-quantized.w4a16
 tasks:
   - name: arc_challenge
     metrics:

--- a/mistralai/Mistral-Small-3.1-24B-Instruct-2503/accuracy/tasks.yml
+++ b/mistralai/Mistral-Small-3.1-24B-Instruct-2503/accuracy/tasks.yml
@@ -59,4 +59,3 @@ tasks:
     metrics:
       - name: acc,none
         value: 0.5545
-  

--- a/mistralai/Mistral-Small-3.1-24B-Instruct-2503/accuracy/tasks.yml
+++ b/mistralai/Mistral-Small-3.1-24B-Instruct-2503/accuracy/tasks.yml
@@ -1,30 +1,62 @@
+# from gs://nm-vllm-certs/model-validation/lmeval/mistralai/Mistral-Small-3.1-24B-Instruct-2503/cuda/0.8.4.post1/ibm02-a100-octo/llm_eval_0.json
 tasks:
   - name: arc_challenge
     metrics:
       - name: acc_norm,none
-        value: 0.7278
+        value: 0.715
 
   - name: gsm8k
     metrics:
       - name: exact_match,strict-match
-        value: 0.5668
+        value: 0.89
 
   - name: hellaswag
     metrics:
       - name: acc_norm,none
-        value: 0.8370
+        value: 0.8573
 
   - name: mmlu
     metrics:
       - name: acc,none
-        value: 0.8067
+        value: 0.8109
 
   - name: truthfulqa_mc2
     metrics:
       - name: acc,none
-        value: 0.7062
+        value: 0.6409
 
   - name: winogrande
     metrics:
       - name: acc,none
         value: 0.8374
+
+  - name: leaderboard_ifeval
+    metrics:
+      - name: inst_level_strict_acc,none
+        value: 0.729
+
+  # - name: leaderboard_bbh
+  #   metrics:
+  #     - name: acc-norm,none
+  #       value: 0.5319
+
+  # - name: leaderboard_math_hard
+  #   metrics:
+  #     - name: exact_match,none
+  #       value: 0.1477
+
+  # - name: leaderboard_gpqa
+  #   metrics:
+  #     - name: acc-norm,none
+  #       value: 0.3176
+
+  # - name: leaderboard_musr
+  #   metrics:
+  #     - name: acc-norm,none
+  #       value: 0.4601
+
+  - name: leaderboard_mmlu_pro
+    metrics:
+      - name: acc,none
+        value: 0.5545
+  

--- a/mistralai/Mistral-Small-3.1-24B-Instruct-2503/accuracy/tasks.yml
+++ b/mistralai/Mistral-Small-3.1-24B-Instruct-2503/accuracy/tasks.yml
@@ -1,197 +1,30 @@
-# collected vllm v0.8.3.post1 on k8s-a100-duo
 tasks:
-  - name: leaderboard_math_algebra_hard
-    metrics:
-      - name: exact_match,none
-        value: 0.703
-
-  - name: leaderboard_math_counting_and_prob_hard
-    metrics:
-      - name: exact_match,none
-        value: 0.489
-
-  - name: leaderboard_math_geometry_hard
-    metrics:
-      - name: exact_match,none
-        value: 0.366
-
-  - name: leaderboard_math_intermediate_algebra_hard
-    metrics:
-      - name: exact_match,none
-        value: 0.283
-
-  - name: leaderboard_math_num_theory_hard
-    metrics:
-      - name: exact_match,none
-        value: 0.476
-
-  - name: leaderboard_math_prealgebra_hard
-    metrics:
-      - name: exact_match,none
-        value: 0.695
-
-  - name: leaderboard_math_precalculus_hard
-    metrics:
-      - name: exact_match,none
-        value: 0.355
-
-  - name: leaderboard_bbh_boolean_expressions
+  - name: arc_challenge
     metrics:
       - name: acc_norm,none
-        value: 0.876
+        value: 0.7278
 
-  - name: leaderboard_bbh_causal_judgement
+  - name: gsm8k
+    metrics:
+      - name: exact_match,strict-match
+        value: 0.5668
+
+  - name: hellaswag
     metrics:
       - name: acc_norm,none
-        value: 0.652
+        value: 0.8370
 
-  - name: leaderboard_bbh_date_understanding
+  - name: mmlu
     metrics:
-      - name: acc_norm,none
-        value: 0.796
+      - name: acc,none
+        value: 0.8067
 
-  - name: leaderboard_bbh_disambiguation_qa
+  - name: truthfulqa_mc2
     metrics:
-      - name: acc_norm,none
-        value: 0.696
+      - name: acc,none
+        value: 0.7062
 
-  - name: leaderboard_bbh_formal_fallacies
+  - name: winogrande
     metrics:
-      - name: acc_norm,none
-        value: 0.684
-
-  - name: leaderboard_bbh_geometric_shapes
-    metrics:
-      - name: acc_norm,none
-        value: 0.508
-
-  - name: leaderboard_bbh_hyperbaton
-    metrics:
-      - name: acc_norm,none
-        value: 0.78
-
-  - name: leaderboard_bbh_logical_deduction_five_objects
-    metrics:
-      - name: acc_norm,none
-        value: 0.632
-
-  - name: leaderboard_bbh_logical_deduction_seven_objects
-    metrics:
-      - name: acc_norm,none
-        value: 0.636
-
-  - name: leaderboard_bbh_logical_deduction_three_objects
-    metrics:
-      - name: acc_norm,none
-        value: 0.876
-
-  - name: leaderboard_bbh_movie_recommendation
-    metrics:
-      - name: acc_norm,none
-        value: 0.848
-
-  - name: leaderboard_bbh_navigate
-    metrics:
-      - name: acc_norm,none
-        value: 0.688
-
-  - name: leaderboard_bbh_object_counting
-    metrics:
-      - name: acc_norm,none
-        value: 0.42
-
-  - name: leaderboard_bbh_penguins_in_a_table
-    metrics:
-      - name: acc_norm,none
-        value: 0.767
-
-  - name: leaderboard_bbh_reasoning_about_colored_objects
-    metrics:
-      - name: acc_norm,none
-        value: 0.764
-
-  - name: leaderboard_bbh_ruin_names
-    metrics:
-      - name: acc_norm,none
-        value: 0.868
-
-  - name: leaderboard_bbh_salient_translation_error_detection
-    metrics:
-      - name: acc_norm,none
-        value: 0.684
-
-  - name: leaderboard_bbh_snarks
-    metrics:
-      - name: acc_norm,none
-        value: 0.725
-
-  - name: leaderboard_bbh_sports_understanding
-    metrics:
-      - name: acc_norm,none
-        value: 0.836
-
-  - name: leaderboard_bbh_temporal_sequences
-    metrics:
-      - name: acc_norm,none
-        value: 0.984
-
-  - name: leaderboard_bbh_tracking_shuffled_objects_five_objects
-    metrics:
-      - name: acc_norm,none
-        value: 0.288
-
-  - name: leaderboard_bbh_tracking_shuffled_objects_seven_objects
-    metrics:
-      - name: acc_norm,none
-        value: 0.224
-
-  - name: leaderboard_bbh_tracking_shuffled_objects_three_objects
-    metrics:
-      - name: acc_norm,none
-        value: 0.348
-
-  - name: leaderboard_bbh_web_of_lies
-    metrics:
-      - name: acc_norm,none
-        value: 0.52
-
-  - name: leaderboard_gpqa_diamond
-    metrics:
-      - name: acc_norm,none
-        value: 0.399
-
-  - name: leaderboard_gpqa_extended
-    metrics:
-      - name: acc_norm,none
-        value: 0.405
-
-  - name: leaderboard_gpqa_main
-    metrics:
-      - name: acc_norm,none
-        value: 0.393
-
-  - name: leaderboard_musr_murder_mysteries
-    metrics:
-      - name: acc_norm,none
-        value: 0.556
-
-  - name: leaderboard_musr_object_placements
-    metrics:
-      - name: acc_norm,none
-        value: 0.437
-
-  - name: leaderboard_musr_team_allocation
-    metrics:
-      - name: acc_norm,none
-        value: 0.404
-
-  - name: leaderboard_ifeval
-    metrics:
-      - name: prompt_level_strict_acc,none
-        value: 0.582
-      - name: prompt_level_loose_acc,none
-        value: 0.647
-      - name: inst_level_loose_acc,none
-        value: 0.748
-      - name: inst_level_strict_acc,none
-        value: 0.693
+      - name: acc,none
+        value: 0.8374

--- a/mistralai/Mixtral-8x7B-Instruct-v0.1/accuracy/model_card_tasks.yml
+++ b/mistralai/Mixtral-8x7B-Instruct-v0.1/accuracy/model_card_tasks.yml
@@ -1,3 +1,4 @@
+# no RedHatAI model cards use this base model
 tasks:
   - name: arc_challenge
     metrics:
@@ -28,4 +29,3 @@ tasks:
     metrics:
       - name: acc,none
         value: 0.8224
-

--- a/mistralai/Mixtral-8x7B-Instruct-v0.1/accuracy/model_card_tasks.yml
+++ b/mistralai/Mixtral-8x7B-Instruct-v0.1/accuracy/model_card_tasks.yml
@@ -1,0 +1,31 @@
+tasks:
+  - name: arc_challenge
+    metrics:
+      - name: acc_norm,none
+        value: 0.7048
+
+  - name: gsm8k
+    metrics:
+      - name: exact_match,strict-match
+        value: 0.655
+
+  - name: hellaswag
+    metrics:
+      - name: acc_norm,none
+        value: 0.8733
+
+  - name: mmlu
+    metrics:
+      - name: acc,none
+        value: 0.703
+
+  - name: truthfulqa_mc2
+    metrics:
+      - name: acc,none
+        value: 0.6481
+
+  - name: winogrande
+    metrics:
+      - name: acc,none
+        value: 0.8224
+

--- a/mistralai/Mixtral-8x7B-Instruct-v0.1/accuracy/tasks.yml
+++ b/mistralai/Mixtral-8x7B-Instruct-v0.1/accuracy/tasks.yml
@@ -1,31 +1,62 @@
+# from gs://nm-vllm-certs/model-validation/lmeval/mistralai/Mixtral-8x7B-Instruct-v0.1/cuda/0.8.4.post1/gpu19-h100-octo/llm_eval_0.json
 tasks:
   - name: arc_challenge
     metrics:
       - name: acc_norm,none
-        value: 0.7048
+        value: 0.7107
 
   - name: gsm8k
     metrics:
       - name: exact_match,strict-match
-        value: 0.655
+        value: 0.6459
 
   - name: hellaswag
     metrics:
       - name: acc_norm,none
-        value: 0.8733
+        value: 0.8732
 
   - name: mmlu
     metrics:
       - name: acc,none
-        value: 0.703
+        value: 0.7038
 
   - name: truthfulqa_mc2
     metrics:
       - name: acc,none
-        value: 0.6481
+        value: 0.6466
 
   - name: winogrande
     metrics:
       - name: acc,none
-        value: 0.8224
+        value: 0.8145
 
+  - name: leaderboard_ifeval
+    metrics:
+      - name: inst_level_strict_acc,none
+        value: 0.5755
+
+  # - name: leaderboard_bbh
+  #   metrics:
+  #     - name: acc-norm,none
+  #       value: 0.5319
+
+  # - name: leaderboard_math_hard
+  #   metrics:
+  #     - name: exact_match,none
+  #       value: 0.1477
+
+  # - name: leaderboard_gpqa
+  #   metrics:
+  #     - name: acc-norm,none
+  #       value: 0.3176
+
+  # - name: leaderboard_musr
+  #   metrics:
+  #     - name: acc-norm,none
+  #       value: 0.4601
+
+  - name: leaderboard_mmlu_pro
+    metrics:
+      - name: acc,none
+        value: 0.3815
+  

--- a/mistralai/Mixtral-8x7B-Instruct-v0.1/accuracy/tasks.yml
+++ b/mistralai/Mixtral-8x7B-Instruct-v0.1/accuracy/tasks.yml
@@ -59,4 +59,3 @@ tasks:
     metrics:
       - name: acc,none
         value: 0.3815
-  


### PR DESCRIPTION
SUMMARY:
the nm-cicd repo `accuracy` workflow is being updated to use a model's "base model" tasks.yml as the ground truth for comparison against the results of a current run.  For example, if the `accuracy` workflow is testing the `RedHatAI/Meta-Llama-3.1-8B-Instruct-FP8-dynamic` model, it will collect the results from the execution of the `llm-eval-test` tool, then compare those results against those found in the `meta-llama/Llama-3.1-8B-Instruct/accuracy/tasks.yml` file because this is the base model for our model under test.

Changes in this PR:
* copies the existing `accuracy/tasks.yml` file for all "base models" to `accuracy/model_card_tasks.yml`, and verifies that the task metric values match the value found for that metric in the base model's column of the Evaluation Accuracy table in the HuggingFace model card for a RedHatAI version of that model.
* updates the `accuracy/tasks.yml` file for all "base models" to use task metric values found in the output generated for that model during our testing for Red Hat Summit 2025.  this becomes the new ground truth for accuracy testing.

TEST PLAN:
the [accuracy RedHatAI/Meta-Llama-3.1-8B-Instruct-FP8-dynamic on k8s-h100-duo (derekk-nm)](https://github.com/neuralmagic/nm-cicd/actions/runs/16012248857) workflow run demonstrates one model.  remaining models will be tested over time as test runner resources allow.
