### PR TITLE
Provide more configurations for accuracy testing of models included in model validation 1.1

### DIFF
--- a/HuggingFaceTB/SmolLM3-3B/accuracy/server.yml
+++ b/HuggingFaceTB/SmolLM3-3B/accuracy/server.yml
@@ -1,0 +1,2 @@
+max-model-len: 65536
+gpu_memory_utilization: 0.9

--- a/HuggingFaceTB/SmolLM3-3B/accuracy/tasks.yml
+++ b/HuggingFaceTB/SmolLM3-3B/accuracy/tasks.yml
@@ -1,0 +1,5 @@
+tasks:
+  - name: gsm8k
+    metrics:
+      - name: exact_match,strict-match
+        value: 0

--- a/Qwen/Qwen3-8B/accuracy/tasks.yml
+++ b/Qwen/Qwen3-8B/accuracy/tasks.yml
@@ -1,0 +1,31 @@
+tasks:
+  - name: arc_challenge
+    metrics:
+      - name: acc_norm,none
+        value: 0.6169
+
+  - name: gsm8k
+    metrics:
+      - name: exact_match,strict-match
+        value: 0.7597
+
+  - name: hellaswag
+    metrics:
+      - name: acc_norm,none
+        value: 0.5652
+
+  - name: mmlu
+    metrics:
+      - name: acc,none
+        value: 0.7195
+
+  - name: truthfulqa_mc2
+    metrics:
+      - name: acc,none
+        value: 0.5317
+
+  - name: winogrande
+    metrics:
+      - name: acc,none
+        value: 0.6598
+

--- a/Qwen/Qwen3-8B/storage.yml
+++ b/Qwen/Qwen3-8B/storage.yml
@@ -1,0 +1,3 @@
+# storage configs for https://huggingface.co/Qwen/Qwen3-8B
+model: hf
+data: hf

--- a/Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8/accuracy/tasks.yml
+++ b/Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8/accuracy/tasks.yml
@@ -1,0 +1,31 @@
+tasks:
+  - name: arc_challenge
+    metrics:
+      - name: acc_norm,none
+        value: 0
+
+  - name: gsm8k
+    metrics:
+      - name: exact_match,strict-match
+        value: 0
+
+  - name: hellaswag
+    metrics:
+      - name: acc_norm,none
+        value: 0
+
+  - name: mmlu
+    metrics:
+      - name: acc,none
+        value: 0
+
+  - name: truthfulqa_mc2
+    metrics:
+      - name: acc,none
+        value: 0
+
+  - name: winogrande
+    metrics:
+      - name: acc,none
+        value: 0
+

--- a/Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8/storage.yml
+++ b/Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8/storage.yml
@@ -1,0 +1,3 @@
+# storage configs for https://huggingface.co/Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8
+model: hf
+data: hf

--- a/RedHatAI/DeepSeek-R1-0528-quantized.w4a16/accuracy/server.yml
+++ b/RedHatAI/DeepSeek-R1-0528-quantized.w4a16/accuracy/server.yml
@@ -1,0 +1,3 @@
+max-model-len: 4096
+tensor-parallel-size: 8
+trust-remote-code: true

--- a/RedHatAI/DeepSeek-R1-0528-quantized.w4a16/storage.yml
+++ b/RedHatAI/DeepSeek-R1-0528-quantized.w4a16/storage.yml
@@ -1,0 +1,3 @@
+# storage configs for https://huggingface.co/RedHatAI/DeepSeek-R1-0528-quantized.w4a16
+model: hf
+data: hf

--- a/RedHatAI/Llama-3.1-Nemotron-70B-Instruct-HF-FP8-dynamic/accuracy/server.yml
+++ b/RedHatAI/Llama-3.1-Nemotron-70B-Instruct-HF-FP8-dynamic/accuracy/server.yml
@@ -1,5 +1,5 @@
 enable-chunked-prefill: true
 max-model-len: 4096
-tensor-parallel-size: 4
+tensor-parallel-size: 2
 trust-remote-code: true
 uvicorn-log-level: debug

--- a/RedHatAI/Llama-3.1-Nemotron-70B-Instruct-HF-FP8-dynamic/accuracy/server.yml
+++ b/RedHatAI/Llama-3.1-Nemotron-70B-Instruct-HF-FP8-dynamic/accuracy/server.yml
@@ -1,0 +1,5 @@
+enable-chunked-prefill: true
+max-model-len: 4096
+tensor-parallel-size: 4
+trust-remote-code: true
+uvicorn-log-level: debug

--- a/RedHatAI/Llama-3.1-Nemotron-70B-Instruct-HF-FP8-dynamic/accuracy/tasks.yml
+++ b/RedHatAI/Llama-3.1-Nemotron-70B-Instruct-HF-FP8-dynamic/accuracy/tasks.yml
@@ -1,0 +1,60 @@
+tasks:
+  - name: arc_challenge
+    metrics:
+      - name: acc_norm,none
+        value: 0.9309
+
+  - name: gsm8k
+    metrics:
+      - name: exact_match,strict-match
+        value: 0.7013
+
+  - name: hellaswag
+    metrics:
+      - name: acc_norm,none
+        value: 0.8739
+
+  - name: mmlu
+    metrics:
+      - name: acc,none
+        value: 0.8351
+
+  - name: truthfulqa_mc2
+    metrics:
+      - name: acc,none
+        value: 0.5597
+
+  - name: winogrande
+    metrics:
+      - name: acc,none
+        value: 0.8493
+
+  # following are placeholders for mid-level "leaderboard_*" tasks
+  # (OpenLLM v2) waiting for info on how to calculate the metric
+  # values from the individual sub tasks.
+
+  # - name: leaderboard_ifeval
+  #   metrics:
+  #     - name: inst_level_strict_acc,none
+  #       value: 0.7332
+
+  # - name: leaderboard_bbh
+  #   metrics:
+  #     - name: acc-norm,none
+  #       value: 0.4712
+
+  # TODO: need to identify if this is available
+  # - name: leaderboard_math_v_5
+  #   metrics:
+  #     - name: exact_match,none
+  #       value: 0.2385
+
+  # - name: leaderboard_musr
+  #   metrics:
+  #     - name: acc-norm,none
+  #       value: 0.135
+
+  # - name: leaderboard_mmlu_pro
+  #   metrics:
+  #     - name: acc,none
+  #       value: 0.4345

--- a/RedHatAI/Qwen3-8B-FP8-dynamic/storage.yml
+++ b/RedHatAI/Qwen3-8B-FP8-dynamic/storage.yml
@@ -1,0 +1,3 @@
+# storage configs for https://huggingface.co/RedHatAI/Qwen3-8B-FP8-dynamic
+model: hf
+data: hf

--- a/RedHatAI/SmolLM3-3B-FP8-dynamic/storage.yml
+++ b/RedHatAI/SmolLM3-3B-FP8-dynamic/storage.yml
@@ -1,0 +1,3 @@
+# storage configs for https://huggingface.co/RedHatAI/SmolLM3-3B-FP8-dynamic
+model: hf
+data: hf

--- a/RedHatAI/gemma-2-9b-it-FP8/accuracy/client.yml
+++ b/RedHatAI/gemma-2-9b-it-FP8/accuracy/client.yml
@@ -1,0 +1,2 @@
+no-chat-template:
+num_fewshot: 5

--- a/RedHatAI/gemma-2-9b-it-FP8/accuracy/client.yml
+++ b/RedHatAI/gemma-2-9b-it-FP8/accuracy/client.yml
@@ -1,2 +1,1 @@
-no-chat-template:
 num_fewshot: 5

--- a/RedHatAI/gemma-2-9b-it-FP8/accuracy/client.yml
+++ b/RedHatAI/gemma-2-9b-it-FP8/accuracy/client.yml
@@ -1,1 +1,0 @@
-num_fewshot: 5

--- a/RedHatAI/gemma-2-9b-it-FP8/accuracy/server.yml
+++ b/RedHatAI/gemma-2-9b-it-FP8/accuracy/server.yml
@@ -1,3 +1,2 @@
 gpu_memory_utilization: 0.4
-add_bos_token: true
 max-model-len: 4096

--- a/RedHatAI/gemma-2-9b-it-FP8/accuracy/server.yml
+++ b/RedHatAI/gemma-2-9b-it-FP8/accuracy/server.yml
@@ -1,0 +1,3 @@
+gpu_memory_utilization: 0.4
+add_bos_token: true
+max-model-len: 4096

--- a/RedHatAI/gemma-2-9b-it-FP8/storage.yml
+++ b/RedHatAI/gemma-2-9b-it-FP8/storage.yml
@@ -1,3 +1,3 @@
-# storage configs for https://huggingface.co/RedHatAI/DeepSeek-R1-0528-quantized.w4a16
+# storage configs for https://huggingface.co/RedHatAI/gemma-2-9b-it-FP8
 model: hf
 data: hf

--- a/RedHatAI/gemma-2-9b-it-FP8/storage.yml
+++ b/RedHatAI/gemma-2-9b-it-FP8/storage.yml
@@ -1,0 +1,3 @@
+# storage configs for https://huggingface.co/RedHatAI/DeepSeek-R1-0528-quantized.w4a16
+model: hf
+data: hf

--- a/RedHatAI/gemma-3n-E4B-it-FP8-dynamic/accuracy/server.yml
+++ b/RedHatAI/gemma-3n-E4B-it-FP8-dynamic/accuracy/server.yml
@@ -1,0 +1,6 @@
+gpu_memory_utilization: 0.8
+max-model-len: 4096
+add_bos_token: false
+enable_chunked_prefill: true
+enforce_eager: true
+trust_remote_code: true

--- a/RedHatAI/gemma-3n-E4B-it-FP8-dynamic/storage.yml
+++ b/RedHatAI/gemma-3n-E4B-it-FP8-dynamic/storage.yml
@@ -1,0 +1,3 @@
+# storage configs for https://huggingface.co/RedHatAI/gemma-3n-E4B-it-FP8-dynamic
+model: hf
+data: hf

--- a/google/gemma-2-9b-it/accuracy/client.yml
+++ b/google/gemma-2-9b-it/accuracy/client.yml
@@ -1,0 +1,2 @@
+no-chat-template:
+num_fewshot: 5

--- a/google/gemma-2-9b-it/accuracy/client.yml
+++ b/google/gemma-2-9b-it/accuracy/client.yml
@@ -1,2 +1,1 @@
-no-chat-template:
 num_fewshot: 5

--- a/google/gemma-2-9b-it/accuracy/client.yml
+++ b/google/gemma-2-9b-it/accuracy/client.yml
@@ -1,1 +1,0 @@
-num_fewshot: 5

--- a/google/gemma-2-9b-it/accuracy/server.yml
+++ b/google/gemma-2-9b-it/accuracy/server.yml
@@ -1,0 +1,3 @@
+gpu_memory_utilization: 0.4
+add_bos_token: true
+max-model-len: 4096

--- a/google/gemma-2-9b-it/accuracy/tasks.yml
+++ b/google/gemma-2-9b-it/accuracy/tasks.yml
@@ -1,0 +1,30 @@
+tasks:
+  - name: arc_challenge
+    metrics:
+      - name: acc_norm,none
+        value: 0.715
+
+  - name: gsm8k
+    metrics:
+      - name: exact_match,strict-match
+        value: 0.7626
+
+  - name: hellaswag
+    metrics:
+      - name: acc_norm,none
+        value: 0.8191
+
+  - name: mmlu
+    metrics:
+      - name: acc,none
+        value: 0.7228
+
+  - name: truthfulqa_mc2
+    metrics:
+      - name: acc,none
+        value: 0.6032
+
+  - name: winogrande
+    metrics:
+      - name: acc,none
+        value: 0.7711

--- a/google/gemma-2-9b-it/storage.yml
+++ b/google/gemma-2-9b-it/storage.yml
@@ -1,0 +1,3 @@
+# https://huggingface.co/google/gemma-2-9b-it
+model: hf
+data: hf

--- a/google/gemma-3n-E4B-it/accuracy/server.yml
+++ b/google/gemma-3n-E4B-it/accuracy/server.yml
@@ -1,0 +1,6 @@
+gpu_memory_utilization: 0.8
+max-model-len: 4096
+add_bos_token: false
+enable_chunked_prefill: true
+enforce_eager: true
+trust_remote_code: true

--- a/google/gemma-3n-E4B-it/accuracy/tasks.yml
+++ b/google/gemma-3n-E4B-it/accuracy/tasks.yml
@@ -1,0 +1,30 @@
+tasks:
+  - name: arc_challenge
+    metrics:
+      - name: acc_norm,none
+        value: 0.6024
+
+  - name: gsm8k
+    metrics:
+      - name: exact_match,strict-match
+        value: 0.6012
+
+  - name: hellaswag
+    metrics:
+      - name: acc_norm,none
+        value: 0.7494
+
+  - name: mmlu
+    metrics:
+      - name: acc,none
+        value: 0.6414
+
+  - name: truthfulqa_mc2
+    metrics:
+      - name: acc,none
+        value: 0.5487
+
+  - name: winogrande
+    metrics:
+      - name: acc,none
+        value: 0.6835

--- a/llava-hf/LLaVA-NeXT-Video-7B-hf/accuracy/server.yml
+++ b/llava-hf/LLaVA-NeXT-Video-7B-hf/accuracy/server.yml
@@ -4,4 +4,3 @@ enable-chunked-prefill: true
 max-model-len: 5000
 tensor-parallel-size: 1
 trust-remote-code: true
-uvicorn-log-level: debug

--- a/mistralai/Mixtral-8x7B-Instruct-v0.1/accuracy/server.yml
+++ b/mistralai/Mixtral-8x7B-Instruct-v0.1/accuracy/server.yml
@@ -3,3 +3,4 @@ model: "mistralai/Mixtral-8x7B-Instruct-v0.1"
 trust-remote-code: true
 tensor-parallel-size: 8
 max-model-len: 16384
+tokenizer-mode: "mistral"

--- a/moonshotai/Kimi-K2-Instruct/accuracy/tasks.yml
+++ b/moonshotai/Kimi-K2-Instruct/accuracy/tasks.yml
@@ -1,0 +1,5 @@
+tasks:
+  - name: gsm8k
+    metrics:
+      - name: exact_match,strict-match
+        value: 0.9492

--- a/nvidia/Llama-3.1-Nemotron-70B-Instruct-HF/accuracy/server.yml
+++ b/nvidia/Llama-3.1-Nemotron-70B-Instruct-HF/accuracy/server.yml
@@ -1,5 +1,5 @@
 enable-chunked-prefill: true
 max-model-len: 4096
-tensor-parallel-size: 4
+tensor-parallel-size: 2
 trust-remote-code: true
 uvicorn-log-level: debug

--- a/nvidia/Llama-3.1-Nemotron-70B-Instruct-HF/accuracy/server.yml
+++ b/nvidia/Llama-3.1-Nemotron-70B-Instruct-HF/accuracy/server.yml
@@ -1,0 +1,5 @@
+enable-chunked-prefill: true
+max-model-len: 4096
+tensor-parallel-size: 4
+trust-remote-code: true
+uvicorn-log-level: debug

--- a/nvidia/Llama-3.1-Nemotron-70B-Instruct-HF/accuracy/tasks.yml
+++ b/nvidia/Llama-3.1-Nemotron-70B-Instruct-HF/accuracy/tasks.yml
@@ -1,0 +1,60 @@
+tasks:
+  - name: arc_challenge
+    metrics:
+      - name: acc_norm,none
+        value: 0.9309
+
+  - name: gsm8k
+    metrics:
+      - name: exact_match,strict-match
+        value: 0.7013
+
+  - name: hellaswag
+    metrics:
+      - name: acc_norm,none
+        value: 0.8739
+
+  - name: mmlu
+    metrics:
+      - name: acc,none
+        value: 0.8351
+
+  - name: truthfulqa_mc2
+    metrics:
+      - name: acc,none
+        value: 0.5597
+
+  - name: winogrande
+    metrics:
+      - name: acc,none
+        value: 0.8493
+
+  # following are placeholders for mid-level "leaderboard_*" tasks
+  # (OpenLLM v2) waiting for info on how to calculate the metric
+  # values from the individual sub tasks.
+
+  # - name: leaderboard_ifeval
+  #   metrics:
+  #     - name: inst_level_strict_acc,none
+  #       value: 0.7332
+
+  # - name: leaderboard_bbh
+  #   metrics:
+  #     - name: acc-norm,none
+  #       value: 0.4712
+
+  # TODO: need to identify if this is available
+  # - name: leaderboard_math_v_5
+  #   metrics:
+  #     - name: exact_match,none
+  #       value: 0.2385
+
+  # - name: leaderboard_musr
+  #   metrics:
+  #     - name: acc-norm,none
+  #       value: 0.135
+
+  # - name: leaderboard_mmlu_pro
+  #   metrics:
+  #     - name: acc,none
+  #       value: 0.4345


### PR DESCRIPTION
SUMMARY:
Adding relevant configuration files for running the `nm-cicd` `accuracy` workflow/action against models being included in the v2.0 of our third-party model validation initiative.  This PR incorporates about half of the new models.  Another PR will include the other models.  Included here (a parent model is also included if the listed model is from RedHat):
* RedHatAI/DeepSeek-R1-0528-quantized.w4a16
* RedHatAI/Llama-3.1-Nemotron-70B-Instruct-HF-FP8-dynamic
* RedHatAI/Qwen3-8B-FP8-dynamic
* RedHatAI/SmolLM3-3B-FP8-dynamic
* RedHatAI/gemma-2-9b-it-FP8
* RedHatAI/gemma-3n-E4B-it-FP8-dynamic
* llava-hf/LLaVA-NeXT-Video-7B-hf/accuracy/server.yml
* moonshotai/Kimi-K2-Instruct/accuracy/tasks.yml

TEST PLAN:
The standalone `accuracy` workflow was run for each of the models.
The accuracy workflow fails for few of the models due to missing dependencies or other issues that need to be investigated.
Some models do not have any source of ground truth available at the moment.  Those have a metric value of 0 until we can run those models.
