### PR TITLE
Add performance config for microsoft/Phi-3-medium-4k-instruct

### DIFF
--- a/microsoft/Phi-3-medium-4k-instruct/performance/server.yml
+++ b/microsoft/Phi-3-medium-4k-instruct/performance/server.yml
@@ -1,0 +1,6 @@
+enable-chunked-prefill: true
+max-model-len: 4096
+tensor-parallel-size: 1
+trust-remote-code: true
+uvicorn-log-level: debug
+no-enable-prefix-caching: true


### PR DESCRIPTION
### SUMMARY:
When running vllm with `microsoft/Phi-3-medium-4k-instruct` we get the following error:

```
Value error, User-specified max_model_len (8192) is greater than the derived max_model_len (max_position_embeddings=4096 or model_max_length=None in model's config.json). 
This may lead to incorrect model outputs or CUDA errors. 
To allow overriding this maximum, set the env var VLLM_ALLOW_LONG_MAX_MODEL_LEN=1 [type=value_error, input_value=ArgsKwargs((), {'model': ...gits_processors': None}), input_type=ArgsKwargs]
```
Because it gets the max_model_len from `model-configs/common/performance/server.yml`
```
WARNING  neuralmagic.utils:utils.py:104 No performance server config found for microsoft/Phi-3-medium-4k-instruct, using fallback=PosixPath('model-configs/common/performance/server.yml')
```
Example run: https://github.com/neuralmagic/nm-cicd/actions/runs/17684609008

### TEST PLAN:
Adding this performance config solves this issue:
Example run: https://github.com/neuralmagic/nm-cicd/actions/runs/17684808798