### PR TITLE
Add model-validation-configs for Llama-4-Scout-17B-16E-Instruct-NVFP4

### DIFF
--- a/meta-llama/Llama-4-Scout-17B-16E-Instruct-NVFP4/accuracy/server.yml
+++ b/meta-llama/Llama-4-Scout-17B-16E-Instruct-NVFP4/accuracy/server.yml
@@ -1,0 +1,3 @@
+trust-remote-code: true
+tensor-parallel-size: 2
+max-model-len: 16384

--- a/meta-llama/Llama-4-Scout-17B-16E-Instruct-NVFP4/accuracy/tasks.yml
+++ b/meta-llama/Llama-4-Scout-17B-16E-Instruct-NVFP4/accuracy/tasks.yml
@@ -1,0 +1,31 @@
+# ground truth values from base Llama-4-Scout-17B-16E-Instruct, pending HPU validation
+tasks:
+  - name: arc_challenge
+    metrics:
+      - name: acc_norm,none
+        value: 0.6936
+
+  - name: gsm8k
+    metrics:
+      - name: exact_match,strict-match
+        value: 0.9044
+
+  - name: hellaswag
+    metrics:
+      - name: acc_norm,none
+        value: 0.8514
+
+  - name: mmlu
+    metrics:
+      - name: acc,none
+        value: 0.8042
+
+  - name: truthfulqa_mc2
+    metrics:
+      - name: acc,none
+        value: 0.5975
+
+  - name: winogrande
+    metrics:
+      - name: acc,none
+        value: 0.7861

--- a/meta-llama/Llama-4-Scout-17B-16E-Instruct-NVFP4/performance/server.yml
+++ b/meta-llama/Llama-4-Scout-17B-16E-Instruct-NVFP4/performance/server.yml
@@ -1,0 +1,5 @@
+trust-remote-code: true
+tensor-parallel-size: 2
+max-model-len: 8192
+no-enable-prefix-caching: true
+uvicorn-log-level: debug


### PR DESCRIPTION
## Summary

- Add accuracy and performance configs for `meta-llama/Llama-4-Scout-17B-16E-Instruct-NVFP4`
- Needed for HPU/Gaudi model validation (currently commented out in nm-cicd `hpu-models.txt` due to missing configs)
- Ground truth values based on base Llama-4-Scout model, pending HPU validation run to calibrate

## Test plan

- [ ] Run lm-eval with `model_validation_configs_ref=add-hpu-model-configs` to validate configs load correctly