### PR TITLE
INFERENG-6076: Fix granite-4.0-h-small TP for HPU

### DIFF
--- a/ibm-granite/granite-4.0-h-small/performance/server.yml
+++ b/ibm-granite/granite-4.0-h-small/performance/server.yml
@@ -1,4 +1,4 @@
 max-model-len: 4025
-tensor-parallel-size: 2
+tensor-parallel-size: 1
 trust-remote-code: true
 uvicorn-log-level: debug


### PR DESCRIPTION
## Summary
- Reduce `tensor-parallel-size` from 2 to 1 for `ibm-granite/granite-4.0-h-small` performance server config
- granite-4.0-h-small is a hybrid Mamba/Attention model (1.8B params) with GQA group counts not divisible by 2, causing `assert n_groups % self.tp_size == 0` on HPU
- TP=1 is sufficient for this small model and matches the pattern of other working HPU models

## Test plan
- [ ] Re-run HPU smoke tests via `ocp-test.yml` with `config_ref=INFERENG-6076/granite-hpu-tp-fix` to verify granite-4.0-h-small passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)