### PR TITLE
Add Mistral-Medium-3.5-128B model validation config

### DIFF
--- a/mistralai/Mistral-Medium-3.5-128B/accuracy/server.yml
+++ b/mistralai/Mistral-Medium-3.5-128B/accuracy/server.yml
@@ -1,7 +1,7 @@
-tensor-parallel-size: 8
+tensor-parallel-size: 4
 trust-remote-code: true
-gpu_memory_utilization: 0.8
-max-model-len: 65536
+gpu_memory_utilization: 0.9
+max-model-len: 16384
 tokenizer_mode: mistral
 config_format: mistral
 load_format: mistral

--- a/mistralai/Mistral-Medium-3.5-128B/accuracy/server.yml
+++ b/mistralai/Mistral-Medium-3.5-128B/accuracy/server.yml
@@ -1,0 +1,7 @@
+tensor-parallel-size: 8
+trust-remote-code: true
+gpu_memory_utilization: 0.8
+max-model-len: 65536
+tokenizer_mode: mistral
+config_format: mistral
+load_format: mistral

--- a/mistralai/Mistral-Medium-3.5-128B/accuracy/server.yml
+++ b/mistralai/Mistral-Medium-3.5-128B/accuracy/server.yml
@@ -1,7 +1,7 @@
 tensor-parallel-size: 4
 trust-remote-code: true
 gpu_memory_utilization: 0.9
-max-model-len: 16384
+max-model-len: auto
 tokenizer_mode: mistral
 config_format: mistral
 load_format: mistral

--- a/mistralai/Mistral-Medium-3.5-128B/accuracy/server.yml
+++ b/mistralai/Mistral-Medium-3.5-128B/accuracy/server.yml
@@ -5,3 +5,7 @@ max-model-len: 65536
 tokenizer_mode: mistral
 config_format: mistral
 load_format: mistral
+enable-auto-tool-choice: true
+tool-call-parser: mistral
+reasoning-parser: mistral
+limit-mm-per-prompt: '{"image": 10}'

--- a/mistralai/Mistral-Medium-3.5-128B/accuracy/tasks.yml
+++ b/mistralai/Mistral-Medium-3.5-128B/accuracy/tasks.yml
@@ -1,0 +1,9 @@
+# from vLLM recipe: vllm-project/recipes models/mistralai/Mistral-Medium-3.5-128B.yaml
+# Benchmarked on MI300X TP=8, FP8 native weights
+tasks:
+  - name: gsm8k
+    metrics:
+      - name: exact_match,flexible-extract
+        value: 0.929
+      - name: exact_match,strict-match
+        value: 0.876

--- a/mistralai/Mistral-Medium-3.5-128B/accuracy/tasks.yml
+++ b/mistralai/Mistral-Medium-3.5-128B/accuracy/tasks.yml
@@ -1,9 +1,12 @@
-# from vLLM recipe: vllm-project/recipes models/mistralai/Mistral-Medium-3.5-128B.yaml
-# Benchmarked on MI300X TP=8, FP8 native weights
+# from SGLang cookbook: docs.sglang.io/cookbook/autoregressive/Mistral/Mistral-Medium-3.5
+# Validated on 4x H200 (Hopper), TP=4, FP8 native weights
 tasks:
   - name: gsm8k
     metrics:
-      - name: exact_match,flexible-extract
-        value: 0.929
-      - name: exact_match,strict-match
-        value: 0.876
+      - name: acc
+        value: 0.945
+
+  - name: mmmu
+    metrics:
+      - name: acc
+        value: 0.586

--- a/mistralai/Mistral-Medium-3.5-128B/performance/server.yml
+++ b/mistralai/Mistral-Medium-3.5-128B/performance/server.yml
@@ -1,8 +1,8 @@
-tensor-parallel-size: 8
+tensor-parallel-size: 4
 trust-remote-code: true
-gpu_memory_utilization: 0.8
-max-model-len: 65536
-max_num_batched_tokens: 16384
+gpu_memory_utilization: 0.9
+max-model-len: 16384
+max_num_batched_tokens: 8192
 max_num_seqs: 128
 tokenizer_mode: mistral
 config_format: mistral

--- a/mistralai/Mistral-Medium-3.5-128B/performance/server.yml
+++ b/mistralai/Mistral-Medium-3.5-128B/performance/server.yml
@@ -10,3 +10,4 @@ load_format: mistral
 enable-auto-tool-choice: true
 tool-call-parser: mistral
 reasoning-parser: mistral
+limit-mm-per-prompt: '{"image": 10}'

--- a/mistralai/Mistral-Medium-3.5-128B/performance/server.yml
+++ b/mistralai/Mistral-Medium-3.5-128B/performance/server.yml
@@ -1,7 +1,7 @@
 tensor-parallel-size: 4
 trust-remote-code: true
 gpu_memory_utilization: 0.9
-max-model-len: 16384
+max-model-len: auto
 max_num_batched_tokens: 8192
 max_num_seqs: 128
 tokenizer_mode: mistral

--- a/mistralai/Mistral-Medium-3.5-128B/performance/server.yml
+++ b/mistralai/Mistral-Medium-3.5-128B/performance/server.yml
@@ -1,0 +1,12 @@
+tensor-parallel-size: 8
+trust-remote-code: true
+gpu_memory_utilization: 0.8
+max-model-len: 65536
+max_num_batched_tokens: 16384
+max_num_seqs: 128
+tokenizer_mode: mistral
+config_format: mistral
+load_format: mistral
+enable-auto-tool-choice: true
+tool-call-parser: mistral
+reasoning-parser: mistral


### PR DESCRIPTION
## Summary

- Adds accuracy and performance validation configs for `mistralai/Mistral-Medium-3.5-128B`
- Dense 128B model with native FP8 weights, requires TP=8 (8x H100 or MI300X)
- Accuracy baseline from [vLLM recipe](https://github.com/vllm-project/recipes/blob/main/models/mistralai/Mistral-Medium-3.5-128B.yaml) (GSM8k on MI300X TP=8)
- Performance server config aligned with Mistral's recommended serve flags (Mistral tokenizer/config/load format, tool calling, reasoning parser)

## Files added

- `mistralai/Mistral-Medium-3.5-128B/accuracy/server.yml` — vLLM server config for lm-eval
- `mistralai/Mistral-Medium-3.5-128B/accuracy/tasks.yml` — GSM8k baseline (flexible: 0.929, strict: 0.876)
- `mistralai/Mistral-Medium-3.5-128B/performance/server.yml` — vLLM server config for guidellm

## Notes

- Model ships FP8 natively; requires `--load_format mistral` and `--tokenizer_mode mistral`
- `max-model-len` capped at 65536 to leave headroom for KV cache (model supports 256k but OOMs under load)
- Accuracy values are from the upstream vLLM recipe MI300X benchmarks; will be updated after running on our H100 infra

## Test plan

- [ ] Run `model-validation-ocp` with `ibm-wdc-k8s-h100-octo` label against this model
- [ ] Validate accuracy numbers match baseline within tolerance
- [ ] Run guidellm performance benchmark and capture throughput/latency

Made with [Cursor](https://cursor.com)