### PR TITLE
Fix guidellm failure in accept sync on CPU due to max_model_len too large for cpu

### DIFF
--- a/common/performance/server-cpu.yml
+++ b/common/performance/server-cpu.yml
@@ -1,6 +1,6 @@
 # CPU-specific server configuration for performance tests
 # Uses conservative memory settings appropriate for CPU inference
-max-model-len: 4096
+max-model-len: 2048
 tensor-parallel-size: 1
 trust-remote-code: true
 uvicorn-log-level: debug


### PR DESCRIPTION
SUMMARY:
This PR fixes following error when run guidellm tests in our accept sync on CPU:

`Value error, User-specified max_model_len (4096) is greater than the derived max_model_len (max_position_embeddings=2048.0 or model_max_length=None in model's config.json). To allow overriding this maximum, set the env var VLLM_ALLOW_LONG_MAX_MODEL_LEN=1. VLLM_ALLOW_LONG_MAX_MODEL_LEN must be used with extreme caution. If the model uses relative position encoding (RoPE), positions exceeding derived_max_model_len lead to nan. If the model uses absolute position encoding, positions exceeding derived_max_model_len will cause a CUDA array out-of-bounds error. [type=value_error, input_value=ArgsKwargs((), {'model': ...nderer_num_workers': 1}), input_type=ArgsKwargs]`

e.g. https://github.com/neuralmagic/nm-cicd/actions/runs/27288949747/job/80605087294

TEST PLAN:
With the PR, the guidellm tests passed: https://github.com/neuralmagic/nm-cicd/actions/runs/27300565435
