### PR TITLE
Limit max len to 2048 for lm eval on CPU

### DIFF
--- a/common/accuracy/server-cpu.yml
+++ b/common/accuracy/server-cpu.yml
@@ -1,6 +1,7 @@
 # CPU-specific server configuration for accuracy tests
 # Uses conservative memory settings appropriate for CPU inference
-# Note: max-model-len is omitted to let vLLM auto-detect based on model capabilities
+# Note: set max-model-len to 2048 otherwise vLLM auto-detect can use 40960 which is too large
+max-model-len: 2048
 trust-remote-code: true
 tensor-parallel-size: 1
 block-size: 128


### PR DESCRIPTION
SUMMARY:
The lm eval job on CPU uses 40960 for max_seq_len which caused timeout, e.g. https://github.com/neuralmagic/nm-cicd/actions/runs/27306896140/job/80667572184

`    (EngineCore pid=1907) INFO 06-10 21:39:41 [core.py:109] Initializing a V1 LLM engine (v0.21.0+rhaiv.3) with config: model='Qwen/Qwen3-1.7B', speculative_config=None, tokenizer='Qwen/Qwen3-1.7B', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, tokenizer_revision=None, trust_remote_code=True, dtype=torch.bfloat16, max_seq_len=40960,...`

Need to limit the length to smaller value 2048 similarly as what we did for the guidellm.

TEST PLAN:
Kicked off a run with the PR here: https://github.com/neuralmagic/nm-cicd/actions/runs/27360496278
