### PR TITLE
Add limit for 2 models that run on CPU

### DIFF
--- a/RedHatAI/TinyLlama-1.1B-Chat-v1.0-pruned2.4/accuracy/client.yml
+++ b/RedHatAI/TinyLlama-1.1B-Chat-v1.0-pruned2.4/accuracy/client.yml
@@ -1,2 +1,5 @@
 # limit examples as the default 10,042 takes too long to run on CPU
-limit: 1000
+data:
+  prompt_tokens: 1000
+  output_tokens: 1000
+#limit: 1000

--- a/RedHatAI/TinyLlama-1.1B-Chat-v1.0-pruned2.4/accuracy/client.yml
+++ b/RedHatAI/TinyLlama-1.1B-Chat-v1.0-pruned2.4/accuracy/client.yml
@@ -1,0 +1,2 @@
+# limit examples as the default 10,042 takes too long to run on CPU
+limit: 1000

--- a/RedHatAI/TinyLlama-1.1B-Chat-v1.0-pruned2.4/accuracy/client.yml
+++ b/RedHatAI/TinyLlama-1.1B-Chat-v1.0-pruned2.4/accuracy/client.yml
@@ -2,4 +2,5 @@
 data:
   prompt_tokens: 1000
   output_tokens: 1000
+max-requests: 100
 #limit: 1000

--- a/TinyLlama/TinyLlama-1.1B-Chat-v1.0/accuracy/client.yml
+++ b/TinyLlama/TinyLlama-1.1B-Chat-v1.0/accuracy/client.yml
@@ -1,2 +1,5 @@
 # limit examples as the default 10,042 takes too long to run on CPU
-limit: 1000
+data:
+  prompt_tokens: 1000
+  output_tokens: 1000
+#limit: 1000

--- a/TinyLlama/TinyLlama-1.1B-Chat-v1.0/accuracy/client.yml
+++ b/TinyLlama/TinyLlama-1.1B-Chat-v1.0/accuracy/client.yml
@@ -1,0 +1,2 @@
+# limit examples as the default 10,042 takes too long to run on CPU
+limit: 1000

--- a/TinyLlama/TinyLlama-1.1B-Chat-v1.0/accuracy/client.yml
+++ b/TinyLlama/TinyLlama-1.1B-Chat-v1.0/accuracy/client.yml
@@ -2,4 +2,5 @@
 data:
   prompt_tokens: 1000
   output_tokens: 1000
+max-requests: 100
 #limit: 1000

--- a/common/accuracy/client-cpu.yml
+++ b/common/accuracy/client-cpu.yml
@@ -1,0 +1,6 @@
+# limit examples as the default 10,042 takes too long to run on CPU
+data:
+  prompt_tokens: 1000
+  output_tokens: 1000
+max-requests: 100
+#limit: 1000


### PR DESCRIPTION
SUMMARY:
Two models using the hellaswag task has a default 10,042 examples which results in 40,168 requests to the CPU server that can take ~4.5h to run for each model in the lm eval job. Add a limit to use 1000 examples for the two models so the lm eval test job can run faster.

TEST PLAN:
Kicked off a run with the PR here: https://github.com/neuralmagic/nm-cicd/actions/runs/27708490614/job/81963710129
