### PR TITLE
Add accuracy configs for google/gemma-4-12B-it

### DIFF
--- a/google/gemma-4-12B-it/accuracy/server.yml
+++ b/google/gemma-4-12B-it/accuracy/server.yml
@@ -1,0 +1,5 @@
+gpu_memory_utilization: 0.8
+max-model-len: 4096
+enable_chunked_prefill: true
+enforce_eager: true
+trust_remote_code: true

--- a/google/gemma-4-12B-it/accuracy/tasks.yml
+++ b/google/gemma-4-12B-it/accuracy/tasks.yml
@@ -1,0 +1,30 @@
+tasks:
+  - name: arc_challenge
+    metrics:
+      - name: acc_norm,none
+        value: 0.6024
+
+  - name: gsm8k
+    metrics:
+      - name: exact_match,strict-match
+        value: 0.7665
+
+  - name: hellaswag
+    metrics:
+      - name: acc_norm,none
+        value: 0.7494
+
+  - name: mmlu
+    metrics:
+      - name: acc,none
+        value: 0.6414
+
+  - name: truthfulqa_mc2
+    metrics:
+      - name: acc,none
+        value: 0.5487
+
+  - name: winogrande
+    metrics:
+      - name: acc,none
+        value: 0.6835


### PR DESCRIPTION
## Summary
- Add lm-eval accuracy config for the Gemma 4 Unified (encoder-free) 12B model (`google/gemma-4-12B-it`)
- Server config mirrors `gemma-3n-E4B-it` (chunked prefill, eager mode, 4096 max-model-len)
- Task thresholds are seeded from `gemma-3-12b-it` as a baseline — will need updating after the first successful accuracy run

## Notes
- The `model_registry.yml` in nm-cicd also needs `test_types: [lm_eval]` added for this model (currently `test_types: []`)
- This is needed to enable accuracy testing for the Gemma 4 Unified cherry-pick into nm-vllm-ent

Made with [Cursor](https://cursor.com)