### PR TITLE
Add Gemma 4 accuracy + performance configs for 3.5-EA2

### DIFF
--- a/RedHatAI/Mistral-Small-3.1-24B-Instruct-2503-FP8-dynamic/performance/server.yml
+++ b/RedHatAI/Mistral-Small-3.1-24B-Instruct-2503-FP8-dynamic/performance/server.yml
@@ -1,0 +1,8 @@
+# https://huggingface.co/RedHatAI/Mistral-Small-3.1-24B-Instruct-2503-FP8-dynamic
+# FP8 repo lacks consolidated.safetensors, so vLLM defaults to HF tokenizer
+# path which crashes (CachedMistralCommonBackend missing is_fast).
+# Force Mistral tokenizer mode to use the correct tokenizer backend.
+tokenizer-mode: mistral
+enable-chunked-prefill: true
+trust-remote-code: true
+uvicorn-log-level: debug

--- a/RedHatAI/NVIDIA-Nemotron-3-Super-120B-A12B-FP8/accuracy/server.yml
+++ b/RedHatAI/NVIDIA-Nemotron-3-Super-120B-A12B-FP8/accuracy/server.yml
@@ -1,0 +1,6 @@
+# MoE model with Mamba architecture - needs reduced max_num_seqs to fit cache blocks
+trust-remote-code: true
+tensor-parallel-size: 2
+max-model-len: 8192
+max-num-seqs: 256
+gpu-memory-utilization: 0.95

--- a/RedHatAI/NVIDIA-Nemotron-3-Super-120B-A12B-FP8/performance/server.yml
+++ b/RedHatAI/NVIDIA-Nemotron-3-Super-120B-A12B-FP8/performance/server.yml
@@ -1,0 +1,7 @@
+# MoE model with Mamba architecture - needs reduced max_num_seqs to fit cache blocks
+trust-remote-code: true
+tensor-parallel-size: 2
+max-model-len: 8192
+max-num-seqs: 256
+gpu-memory-utilization: 0.95
+uvicorn-log-level: debug

--- a/google/gemma-4-12B-it/accuracy/server.yml
+++ b/google/gemma-4-12B-it/accuracy/server.yml
@@ -1,6 +1,3 @@
 # https://huggingface.co/google/gemma-4-12B-it
-gpu_memory_utilization: 0.8
-max-model-len: 4096
 enable_chunked_prefill: true
-enforce_eager: true
 trust_remote_code: true

--- a/google/gemma-4-12B-it/accuracy/server.yml
+++ b/google/gemma-4-12B-it/accuracy/server.yml
@@ -1,3 +1,4 @@
 # https://huggingface.co/google/gemma-4-12B-it
+max-model-len: auto
 enable_chunked_prefill: true
 trust_remote_code: true

--- a/google/gemma-4-12B-it/accuracy/server.yml
+++ b/google/gemma-4-12B-it/accuracy/server.yml
@@ -1,0 +1,6 @@
+# https://huggingface.co/google/gemma-4-12B-it
+gpu_memory_utilization: 0.8
+max-model-len: 4096
+enable_chunked_prefill: true
+enforce_eager: true
+trust_remote_code: true

--- a/google/gemma-4-12B-it/accuracy/tasks.yml
+++ b/google/gemma-4-12B-it/accuracy/tasks.yml
@@ -1,0 +1,32 @@
+# https://huggingface.co/google/gemma-4-12B-it
+# Baseline thresholds seeded from gemma-3-12b-it; update after first run.
+tasks:
+  - name: arc_challenge
+    metrics:
+      - name: acc_norm,none
+        value: 0.6024
+
+  - name: gsm8k
+    metrics:
+      - name: exact_match,strict-match
+        value: 0.7665
+
+  - name: hellaswag
+    metrics:
+      - name: acc_norm,none
+        value: 0.7494
+
+  - name: mmlu
+    metrics:
+      - name: acc,none
+        value: 0.6414
+
+  - name: truthfulqa_mc2
+    metrics:
+      - name: acc,none
+        value: 0.5487
+
+  - name: winogrande
+    metrics:
+      - name: acc,none
+        value: 0.6835

--- a/google/gemma-4-12B-it/performance/server.yml
+++ b/google/gemma-4-12B-it/performance/server.yml
@@ -1,0 +1,9 @@
+# NOTE: max-num-batched-tokens must be >= max-tokens-per-mm-item (2496)
+# because vLLM forces --disable-chunked-mm-input for Gemma4 models
+# due to multimodal-bidirectional attention.
+max-model-len: 8192
+max-num-batched-tokens: 32768
+tensor-parallel-size: 1
+trust-remote-code: true
+uvicorn-log-level: debug
+no-enable-prefix-caching: true

--- a/google/gemma-4-26B-A4B-it/accuracy/server.yml
+++ b/google/gemma-4-26B-A4B-it/accuracy/server.yml
@@ -1,0 +1,6 @@
+# https://huggingface.co/google/gemma-4-26B-A4B-it
+gpu_memory_utilization: 0.8
+max-model-len: 4096
+enable_chunked_prefill: true
+enforce_eager: true
+trust_remote_code: true

--- a/google/gemma-4-26B-A4B-it/accuracy/server.yml
+++ b/google/gemma-4-26B-A4B-it/accuracy/server.yml
@@ -1,6 +1,3 @@
 # https://huggingface.co/google/gemma-4-26B-A4B-it
-gpu_memory_utilization: 0.8
-max-model-len: 4096
 enable_chunked_prefill: true
-enforce_eager: true
 trust_remote_code: true

--- a/google/gemma-4-26B-A4B-it/accuracy/server.yml
+++ b/google/gemma-4-26B-A4B-it/accuracy/server.yml
@@ -1,3 +1,4 @@
 # https://huggingface.co/google/gemma-4-26B-A4B-it
+max-model-len: auto
 enable_chunked_prefill: true
 trust_remote_code: true

--- a/google/gemma-4-26B-A4B-it/accuracy/tasks.yml
+++ b/google/gemma-4-26B-A4B-it/accuracy/tasks.yml
@@ -1,0 +1,32 @@
+# https://huggingface.co/google/gemma-4-26B-A4B-it
+# Baseline thresholds seeded from gemma-3-12b-it; update after first run.
+tasks:
+  - name: arc_challenge
+    metrics:
+      - name: acc_norm,none
+        value: 0.6024
+
+  - name: gsm8k
+    metrics:
+      - name: exact_match,strict-match
+        value: 0.7665
+
+  - name: hellaswag
+    metrics:
+      - name: acc_norm,none
+        value: 0.7494
+
+  - name: mmlu
+    metrics:
+      - name: acc,none
+        value: 0.6414
+
+  - name: truthfulqa_mc2
+    metrics:
+      - name: acc,none
+        value: 0.5487
+
+  - name: winogrande
+    metrics:
+      - name: acc,none
+        value: 0.6835

--- a/google/gemma-4-26B-A4B-it/performance/server.yml
+++ b/google/gemma-4-26B-A4B-it/performance/server.yml
@@ -1,0 +1,9 @@
+# NOTE: max-num-batched-tokens must be >= max-tokens-per-mm-item (2496)
+# because vLLM forces --disable-chunked-mm-input for Gemma4 models
+# due to multimodal-bidirectional attention.
+max-model-len: 8192
+max-num-batched-tokens: 32768
+tensor-parallel-size: 1
+trust-remote-code: true
+uvicorn-log-level: debug
+no-enable-prefix-caching: true

--- a/google/gemma-4-31B-it/accuracy/server.yml
+++ b/google/gemma-4-31B-it/accuracy/server.yml
@@ -1,3 +1,4 @@
 # https://huggingface.co/google/gemma-4-31B-it
+max-model-len: auto
 enable_chunked_prefill: true
 trust_remote_code: true

--- a/google/gemma-4-31B-it/accuracy/server.yml
+++ b/google/gemma-4-31B-it/accuracy/server.yml
@@ -1,0 +1,6 @@
+# https://huggingface.co/google/gemma-4-31B-it
+gpu_memory_utilization: 0.97
+max-model-len: 4096
+enable_chunked_prefill: true
+enforce_eager: true
+trust_remote_code: true

--- a/google/gemma-4-31B-it/accuracy/server.yml
+++ b/google/gemma-4-31B-it/accuracy/server.yml
@@ -1,6 +1,3 @@
 # https://huggingface.co/google/gemma-4-31B-it
-gpu_memory_utilization: 0.97
-max-model-len: 4096
 enable_chunked_prefill: true
-enforce_eager: true
 trust_remote_code: true

--- a/google/gemma-4-31B-it/accuracy/tasks.yml
+++ b/google/gemma-4-31B-it/accuracy/tasks.yml
@@ -1,0 +1,32 @@
+# https://huggingface.co/google/gemma-4-31B-it
+# Baseline thresholds seeded from gemma-3-12b-it; update after first run.
+tasks:
+  - name: arc_challenge
+    metrics:
+      - name: acc_norm,none
+        value: 0.6024
+
+  - name: gsm8k
+    metrics:
+      - name: exact_match,strict-match
+        value: 0.7665
+
+  - name: hellaswag
+    metrics:
+      - name: acc_norm,none
+        value: 0.7494
+
+  - name: mmlu
+    metrics:
+      - name: acc,none
+        value: 0.6414
+
+  - name: truthfulqa_mc2
+    metrics:
+      - name: acc,none
+        value: 0.5487
+
+  - name: winogrande
+    metrics:
+      - name: acc,none
+        value: 0.6835

--- a/google/gemma-4-31B-it/performance/server.yml
+++ b/google/gemma-4-31B-it/performance/server.yml
@@ -1,0 +1,11 @@
+# NOTE: max-num-batched-tokens must be >= max-tokens-per-mm-item (2496)
+# because vLLM forces --disable-chunked-mm-input for Gemma4 models
+# due to multimodal-bidirectional attention.
+max-model-len: 8192
+max-num-batched-tokens: 32768
+tensor-parallel-size: 1
+trust-remote-code: true
+uvicorn-log-level: debug
+no-enable-prefix-caching: true
+# the default value of .90/.92 goes OOM on A100/80GB
+gpu-memory-utilization: 0.97

--- a/google/translategemma-12b-it/accuracy/server.yml
+++ b/google/translategemma-12b-it/accuracy/server.yml
@@ -1,5 +1,3 @@
 # https://huggingface.co/google/translategemma-12b-it
 trust_remote_code: true
-max-model-len: 4096
-enforce_eager: true
 chat-template-content-format: openai

--- a/google/translategemma-12b-it/accuracy/server.yml
+++ b/google/translategemma-12b-it/accuracy/server.yml
@@ -1,3 +1,4 @@
 # https://huggingface.co/google/translategemma-12b-it
+max-model-len: auto
 trust_remote_code: true
 chat-template-content-format: openai

--- a/google/translategemma-12b-it/accuracy/server.yml
+++ b/google/translategemma-12b-it/accuracy/server.yml
@@ -1,0 +1,5 @@
+# https://huggingface.co/google/translategemma-12b-it
+trust_remote_code: true
+max-model-len: 4096
+enforce_eager: true
+chat-template-content-format: openai

--- a/google/translategemma-12b-it/accuracy/tasks.yml
+++ b/google/translategemma-12b-it/accuracy/tasks.yml
@@ -1,0 +1,32 @@
+# https://huggingface.co/google/translategemma-12b-it
+# Baseline thresholds seeded from gemma-3-12b-it; update after first run.
+tasks:
+  - name: arc_challenge
+    metrics:
+      - name: acc_norm,none
+        value: 0.6024
+
+  - name: gsm8k
+    metrics:
+      - name: exact_match,strict-match
+        value: 0.7665
+
+  - name: hellaswag
+    metrics:
+      - name: acc_norm,none
+        value: 0.7494
+
+  - name: mmlu
+    metrics:
+      - name: acc,none
+        value: 0.6414
+
+  - name: truthfulqa_mc2
+    metrics:
+      - name: acc,none
+        value: 0.5487
+
+  - name: winogrande
+    metrics:
+      - name: acc,none
+        value: 0.6835

--- a/google/translategemma-27b-it/accuracy/server.yml
+++ b/google/translategemma-27b-it/accuracy/server.yml
@@ -1,3 +1,4 @@
 # https://huggingface.co/google/translategemma-27b-it
+max-model-len: auto
 trust_remote_code: true
 chat-template-content-format: openai

--- a/google/translategemma-27b-it/accuracy/server.yml
+++ b/google/translategemma-27b-it/accuracy/server.yml
@@ -1,0 +1,6 @@
+# https://huggingface.co/google/translategemma-27b-it
+trust_remote_code: true
+gpu_memory_utilization: 0.97
+max-model-len: 4096
+enforce_eager: true
+chat-template-content-format: openai

--- a/google/translategemma-27b-it/accuracy/server.yml
+++ b/google/translategemma-27b-it/accuracy/server.yml
@@ -1,6 +1,3 @@
 # https://huggingface.co/google/translategemma-27b-it
 trust_remote_code: true
-gpu_memory_utilization: 0.97
-max-model-len: 4096
-enforce_eager: true
 chat-template-content-format: openai

--- a/google/translategemma-27b-it/accuracy/tasks.yml
+++ b/google/translategemma-27b-it/accuracy/tasks.yml
@@ -1,0 +1,32 @@
+# https://huggingface.co/google/translategemma-27b-it
+# Baseline thresholds seeded from gemma-3-12b-it; update after first run.
+tasks:
+  - name: arc_challenge
+    metrics:
+      - name: acc_norm,none
+        value: 0.6024
+
+  - name: gsm8k
+    metrics:
+      - name: exact_match,strict-match
+        value: 0.7665
+
+  - name: hellaswag
+    metrics:
+      - name: acc_norm,none
+        value: 0.7494
+
+  - name: mmlu
+    metrics:
+      - name: acc,none
+        value: 0.6414
+
+  - name: truthfulqa_mc2
+    metrics:
+      - name: acc,none
+        value: 0.5487
+
+  - name: winogrande
+    metrics:
+      - name: acc,none
+        value: 0.6835


### PR DESCRIPTION
* Add gemma4 configs
* Add nemotron 3 super quantized config
* Add accuracy configs for Gemma 4 models (12B, 26B-A4B, 31B): Add lm-eval accuracy configs (server.yml + tasks.yml) for all three
* Gemma 4 instruction-tuned models. Each file includes a link to the HuggingFace model card for reference.
* Add accuracy configs for TranslateGemma (12b, 27b)
* Remove gpu_memory_utilization, max-model-len, enforce_eager from accuracy configs: let vLLM auto-detect max-model-len based on GPU, and use defaults for gpu_memory_utilization and eager mode.
* Set `max-model-len` to auto in accuracy configs
* Add performance/server.yml for Mistral Small FP8-dynamic: FP8 repo lacks consolidated.safetensors, so vLLM defaults to the HF tokenizer path where CachedMistralCommonBackend is missing is_fast. Set tokenizer-mode: mistral to use the correct tokenizer backend (fixes INFERENG-8295)

Co-authored-by: Daniele Trifirò <dtrifiro@redhat.com>
Co-authored-by: Cursor <cursoragent@cursor.com>