### PR TITLE
Add performance server.yml for translategemma-12b-it

### DIFF
--- a/google/translategemma-12b-it/performance/server.yml
+++ b/google/translategemma-12b-it/performance/server.yml
@@ -1,0 +1,4 @@
+# https://huggingface.co/google/translategemma-12b-it
+max-model-len: auto
+trust_remote_code: true
+chat-template-content-format: openai


### PR DESCRIPTION
## Summary

- Adds `google/translategemma-12b-it/performance/server.yml` with `chat-template-content-format: openai`
- translategemma's chat template requires `source_lang_code` and `target_lang_code` extra fields on content parts, which are only preserved when vLLM is started with `--chat-template-content-format openai`
- Without this config, smoke tests fall back to the generic `common/performance/server.yml` which doesn't set this flag, causing a `TemplateError`
- The accuracy config already had this flag set; this extends it to the performance/smoke test path

## Test plan

- [x] Verified the accuracy `server.yml` already has this setting and works
- [ ] Re-run smoke tests with this config to confirm the fix

Made with [Cursor](https://cursor.com)