### PR TITLE
Add accuracy server configs for Mistral-Small-3.1-24B with mistral tokenizer

### DIFF
--- a/RedHatAI/Mistral-Small-3.1-24B-Instruct-2503-FP8-dynamic/accuracy/server.yml
+++ b/RedHatAI/Mistral-Small-3.1-24B-Instruct-2503-FP8-dynamic/accuracy/server.yml
@@ -1,0 +1,7 @@
+enable-chunked-prefill: true
+max-model-len: 9000
+tensor-parallel-size: 1
+trust-remote-code: true
+tokenizer_mode: mistral
+config_format: mistral
+load_format: mistral

--- a/mistralai/Mistral-Small-3.1-24B-Instruct-2503/accuracy/server.yml
+++ b/mistralai/Mistral-Small-3.1-24B-Instruct-2503/accuracy/server.yml
@@ -1,0 +1,7 @@
+enable-chunked-prefill: true
+max-model-len: 9000
+tensor-parallel-size: 1
+trust-remote-code: true
+tokenizer_mode: mistral
+config_format: mistral
+load_format: mistral


### PR DESCRIPTION
## Summary

- Add `accuracy/server.yml` for `mistralai/Mistral-Small-3.1-24B-Instruct-2503` and `RedHatAI/Mistral-Small-3.1-24B-Instruct-2503-FP8-dynamic`
- Sets `tokenizer_mode: mistral`, `config_format: mistral`, `load_format: mistral` matching the existing performance configs and Voxtral precedent
- Fixes lm-eval accuracy tests scoring near-zero on HPU due to HuggingFace tokenizer regex bug ([upstream discussion](https://huggingface.co/mistralai/Mistral-Small-3.1-24B-Instruct-2503/discussions/84#69121093e8b480e709447d5e))

## Test plan

- [ ] Re-run lm-eval on HPU for `mistralai/Mistral-Small-3.1-24B-Instruct-2503` — confirm GSM8K score is within 10% of ground truth (0.89)
- [ ] Re-run lm-eval on HPU for `RedHatAI/Mistral-Small-3.1-24B-Instruct-2503-FP8-dynamic` — confirm GSM8K score is within 10% of ground truth
- [ ] Verify the tokenizer warning no longer appears in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)