### PR TITLE
INFERENG-9361: ROCm server configs for 3.5 GA

### DIFF
--- a/Qwen/Qwen2.5-VL-7B-Instruct/performance/server-rocm.yml
+++ b/Qwen/Qwen2.5-VL-7B-Instruct/performance/server-rocm.yml
@@ -1,0 +1,6 @@
+max-model-len: 8192
+tensor-parallel-size: 1
+trust-remote-code: true
+uvicorn-log-level: debug
+no-enable-prefix-caching: true
+enforce-eager: true

--- a/Qwen/Qwen3-VL-32B-Instruct-FP8/performance/server-rocm.yml
+++ b/Qwen/Qwen3-VL-32B-Instruct-FP8/performance/server-rocm.yml
@@ -1,0 +1,6 @@
+max-model-len: 8192
+tensor-parallel-size: 1
+trust-remote-code: true
+uvicorn-log-level: debug
+no-enable-prefix-caching: true
+enforce-eager: true

--- a/Qwen/Qwen3-VL-32B-Thinking-FP8/performance/server-rocm.yml
+++ b/Qwen/Qwen3-VL-32B-Thinking-FP8/performance/server-rocm.yml
@@ -1,0 +1,7 @@
+max-model-len: 8192
+tensor-parallel-size: 1
+trust-remote-code: true
+uvicorn-log-level: debug
+no-enable-prefix-caching: true
+enforce-eager: true
+reasoning-parser: deepseek_r1

--- a/Qwen/Qwen3.6-35B-A3B/performance/server.yml
+++ b/Qwen/Qwen3.6-35B-A3B/performance/server.yml
@@ -1,0 +1,9 @@
+enable-chunked-prefill: true
+max-model-len: 8192
+tensor-parallel-size: 1
+trust-remote-code: true
+enable-auto-tool-choice: true
+reasoning-parser: deepseek_r1
+tool-call-parser: qwen3_coder
+uvicorn-log-level: debug
+no-enable-prefix-caching: true

--- a/RedHatAI/Qwen2.5-VL-7B-Instruct-FP8-Dynamic/performance/server-rocm.yml
+++ b/RedHatAI/Qwen2.5-VL-7B-Instruct-FP8-Dynamic/performance/server-rocm.yml
@@ -1,0 +1,6 @@
+max-model-len: 8192
+tensor-parallel-size: 1
+trust-remote-code: true
+uvicorn-log-level: debug
+no-enable-prefix-caching: true
+enforce-eager: true

--- a/RedHatAI/Qwen3.6-35B-A3B-FP8-dynamic/accuracy/server-rocm.yml
+++ b/RedHatAI/Qwen3.6-35B-A3B-FP8-dynamic/accuracy/server-rocm.yml
@@ -1,0 +1,1 @@
+enforce-eager: true

--- a/RedHatAI/Qwen3.6-35B-A3B-FP8-dynamic/performance/server-rocm.yml
+++ b/RedHatAI/Qwen3.6-35B-A3B-FP8-dynamic/performance/server-rocm.yml
@@ -1,0 +1,1 @@
+enforce-eager: true

--- a/RedHatAI/Qwen3.6-35B-A3B-FP8-dynamic/performance/server.yml
+++ b/RedHatAI/Qwen3.6-35B-A3B-FP8-dynamic/performance/server.yml
@@ -1,0 +1,9 @@
+enable-chunked-prefill: true
+max-model-len: 8192
+tensor-parallel-size: 1
+trust-remote-code: true
+enable-auto-tool-choice: true
+reasoning-parser: deepseek_r1
+tool-call-parser: qwen3_coder
+uvicorn-log-level: debug
+no-enable-prefix-caching: true

--- a/RedHatAI/gemma-4-26B-A4B-it-FP8-Dynamic/performance/server-rocm.yml
+++ b/RedHatAI/gemma-4-26B-A4B-it-FP8-Dynamic/performance/server-rocm.yml
@@ -1,0 +1,6 @@
+max-model-len: 8192
+tensor-parallel-size: 1
+trust-remote-code: true
+uvicorn-log-level: debug
+no-enable-prefix-caching: true
+moe-backend: triton

--- a/google/gemma-4-26B-A4B-it/performance/server-rocm.yml
+++ b/google/gemma-4-26B-A4B-it/performance/server-rocm.yml
@@ -1,0 +1,6 @@
+max-model-len: 8192
+tensor-parallel-size: 1
+trust-remote-code: true
+uvicorn-log-level: debug
+no-enable-prefix-caching: true
+moe-backend: triton


### PR DESCRIPTION
## Summary

Add ROCm-specific server configs for models that need workarounds on MI300X (ROCm 7.14):

- **gemma-4-26B-A4B** (both variants): `moe-backend: triton` — AITER MoE kernel doesn't support GELU_TANH activation
- **Qwen2.5-VL** (both variants): `enforce-eager: true` — hipErrorInvalidConfiguration in vision encoder profiling
- **Qwen3-VL-32B** (both variants): `enforce-eager: true` — same VL encoder issue
- **Qwen3.6-35B** (both variants): reasoning-parser + tool config

## Validation

All models validated on RC2 image (`quay.io/aipcc/rhaiis/rocm-ubi9:3.5.0-1784802948`):
- OCP smoke: https://github.com/neuralmagic/nm-cicd/actions/runs/30105680710
- New models: https://github.com/neuralmagic/nm-cicd/actions/runs/30564150821

## Related

- Jira https://redhat.atlassian.net/browse/INFERENG-9361
- nm-cicd PR: https://github.com/neuralmagic/nm-cicd/pull/665
- Model selection PR: https://github.com/neuralmagic/nm-cicd/pull/623