### PR TITLE
[INFERENG-9519] Add DiffusionGemma smoke server configs (BF16 + FP8)

### DIFF
--- a/RedHatAI/diffusiongemma-26B-A4B-it-FP8-dynamic/performance/server.yml
+++ b/RedHatAI/diffusiongemma-26B-A4B-it-FP8-dynamic/performance/server.yml
@@ -1,0 +1,14 @@
+# https://huggingface.co/RedHatAI/diffusiongemma-26B-A4B-it-FP8-dynamic
+# FP8-dynamic quantized DiffusionGemma dLLM. The V2 model runner auto-enables for
+# diffusion models (is_diffusion via canvas_length), so VLLM_USE_V2_MODEL_RUNNER
+# is not needed.
+# max-num-seqs MUST be <=4: diffusion state buffers pre-allocate
+# max_seqs x canvas_length x vocab_size and OOM at higher values.
+max-model-len: 8192
+max-num-seqs: 4
+tensor-parallel-size: 1  # cosmetic; profile h100_solo forces TP=1
+trust-remote-code: true
+hf-overrides:
+  diffusion_sampler: entropy_bound
+  diffusion_entropy_bound: 0.1
+uvicorn-log-level: debug

--- a/google/diffusiongemma-26B-A4B-it/performance/server.yml
+++ b/google/diffusiongemma-26B-A4B-it/performance/server.yml
@@ -1,0 +1,13 @@
+# https://huggingface.co/google/diffusiongemma-26B-A4B-it
+# DiffusionGemma dLLM: the V2 model runner auto-enables for diffusion models
+# (is_diffusion via canvas_length), so VLLM_USE_V2_MODEL_RUNNER is not needed.
+# max-num-seqs MUST be <=4: diffusion state buffers pre-allocate
+# max_seqs x canvas_length x vocab_size and OOM at higher values.
+max-model-len: 8192
+max-num-seqs: 4
+tensor-parallel-size: 2  # cosmetic; profile h100_duo forces TP=2
+trust-remote-code: true
+hf-overrides:
+  diffusion_sampler: entropy_bound
+  diffusion_entropy_bound: 0.1
+uvicorn-log-level: debug


### PR DESCRIPTION
## Summary

Adds `performance/server.yml` for the two DiffusionGemma dLLM variants so they can be smoke-validated:

- `google/diffusiongemma-26B-A4B-it` (BF16, TP=2)
- `RedHatAI/diffusiongemma-26B-A4B-it-FP8-dynamic` (FP8, TP=1)

DiffusionGemma requires specific serve settings, all expressible in the server config (verbatim passthrough to `vllm serve --config`):

- `max-num-seqs: 4` — diffusion state buffers pre-allocate `max_seqs × canvas × vocab`; higher values OOM.
- `hf-overrides: {diffusion_sampler: entropy_bound, diffusion_entropy_bound: 0.1}` — required by the diffusion sampler.
- `trust-remote-code: true`.

The V2 model runner auto-enables for diffusion models, so no `VLLM_USE_V2_MODEL_RUNNER` env var is needed.

Pairs with the nm-cicd registry PR and nm-vllm-ent PR #638.

Jira: INFERENG-9519

## Test plan

- YAML validated; smoke path reads `performance/server.yml` only.
- FP8 smoke passes against the RHAIIS 3.5 CUDA image (nm-cicd run 30641858567).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
