### PR TITLE
Add CUDA smoke server configs: Qwen3.6-35B-A3B (Mamba), DeepSeek-V4-Flash-NVFP4-FP8, Qwen3-VL-235B FP8

### DIFF
--- a/Qwen/Qwen3-VL-235B-A22B-Instruct-FP8/performance/server.yml
+++ b/Qwen/Qwen3-VL-235B-A22B-Instruct-FP8/performance/server.yml
@@ -1,0 +1,14 @@
+max-model-len: 8192
+trust-remote-code: true
+uvicorn-log-level: debug
+no-enable-prefix-caching: true
+# Qwen3-VL-235B-A22B is a block-FP8 MoE (moe_intermediate_size=1536). Under the
+# h100_octo profile the harness runs tensor-parallel-size=8, which shards the
+# gate/up output partition to 1536/8 = 192 — not divisible by the FP8 weight
+# block size (block_n=128) — so the engine aborts at startup:
+#   ValueError: The output_size of gate's and up's weight = 192 is not divisible
+#   by weight quantization block_n = 128.
+# Enable expert parallelism so experts (not the intermediate dim) are sharded
+# across ranks; 1536 % 128 == 0 then holds. Confirmed resolved-by-config in vLLM
+# issues #30934, #31262, #17569 (not a code bug).
+enable-expert-parallel: true

--- a/Qwen/Qwen3-VL-235B-A22B-Thinking-FP8/performance/server.yml
+++ b/Qwen/Qwen3-VL-235B-A22B-Thinking-FP8/performance/server.yml
@@ -1,0 +1,14 @@
+max-model-len: 8192
+trust-remote-code: true
+uvicorn-log-level: debug
+no-enable-prefix-caching: true
+# Qwen3-VL-235B-A22B is a block-FP8 MoE (moe_intermediate_size=1536). Under the
+# h100_octo profile the harness runs tensor-parallel-size=8, which shards the
+# gate/up output partition to 1536/8 = 192 — not divisible by the FP8 weight
+# block size (block_n=128) — so the engine aborts at startup:
+#   ValueError: The output_size of gate's and up's weight = 192 is not divisible
+#   by weight quantization block_n = 128.
+# Enable expert parallelism so experts (not the intermediate dim) are sharded
+# across ranks; 1536 % 128 == 0 then holds. Confirmed resolved-by-config in vLLM
+# issues #30934, #31262, #17569 (not a code bug).
+enable-expert-parallel: true

--- a/Qwen/Qwen3.6-35B-A3B/performance/server.yml
+++ b/Qwen/Qwen3.6-35B-A3B/performance/server.yml
@@ -1,0 +1,13 @@
+max-model-len: 8192
+tensor-parallel-size: 1
+trust-remote-code: true
+uvicorn-log-level: debug
+no-enable-prefix-caching: true
+# Hybrid Mamba MoE: each decode sequence needs one Mamba cache block. On 80GB
+# cards the 35B weights leave only a few GiB for cache (2.26-4.39 GiB / ~112-217
+# blocks observed run-to-run), so the default max_num_seqs exceeds the available
+# Mamba cache blocks and CUDA graph capture aborts on startup. Cap concurrency
+# well below the observed block floor and give the cache extra headroom.
+# See vLLM: "max_num_seqs (N) exceeds available Mamba cache blocks (M)".
+max-num-seqs: 64
+gpu-memory-utilization: 0.95

--- a/RedHatAI/DeepSeek-V4-Flash-NVFP4-FP8/performance/server.yml
+++ b/RedHatAI/DeepSeek-V4-Flash-NVFP4-FP8/performance/server.yml
@@ -1,0 +1,10 @@
+max-model-len: 8192
+tensor-parallel-size: 1
+trust-remote-code: true
+uvicorn-log-level: debug
+no-enable-prefix-caching: true
+# DeepSeek-V4 fp8_ds_mla attention layout only supports an fp8 KV cache; with the
+# default kv-cache-dtype=auto the engine aborts on startup with:
+#   AssertionError: DeepseekV4 fp8_ds_mla layout only supports fp8 kv-cache, got auto
+# Pin the KV cache dtype to fp8 to match the ds_mla layout requirement.
+kv-cache-dtype: fp8

--- a/RedHatAI/DeepSeek-V4-Flash-NVFP4-FP8/performance/server.yml
+++ b/RedHatAI/DeepSeek-V4-Flash-NVFP4-FP8/performance/server.yml
@@ -1,5 +1,7 @@
 max-model-len: 8192
-tensor-parallel-size: 1
+# tensor-parallel-size is supplied by the harness from the model registry
+# profile (h100_quad -> 4); omit it here so the config does not fight (and warn
+# about overriding) the command-line --tensor-parallel-size.
 trust-remote-code: true
 uvicorn-log-level: debug
 no-enable-prefix-caching: true


### PR DESCRIPTION
## Summary

Adds per-model `performance/server.yml` overrides to fix CUDA `MODEL_VALIDATION` smoke failures from nm-cicd run [30660465297](https://github.com/neuralmagic/nm-cicd/actions/runs/30660465297). Smoke uses the performance server config.

### Qwen/Qwen3.6-35B-A3B — ✅ verified fixed
Hybrid Mamba MoE: each decode sequence needs one Mamba cache block; on 80GB cards the 35B weights leave only ~112–217 blocks, so the default `max_num_seqs` exceeds available blocks and CUDA graph capture aborts:
```
ValueError: max_num_seqs (N) exceeds available Mamba cache blocks (M)
```
Fix: `max-num-seqs: 64` + `gpu-memory-utilization: 0.95`.
Verified passing: smoke rerun [30821728603](https://github.com/neuralmagic/nm-cicd/actions/runs/30821728603) ✅

### Qwen/Qwen3-VL-235B-A22B-Thinking-FP8 and -Instruct-FP8 — config fix (needs 8×H100 rerun to verify)
Block-FP8 MoE (`moe_intermediate_size=1536`). Under `h100_octo` (TP=8) the gate/up output partition shards to 1536/8=192, not divisible by block_n=128:
```
ValueError: The output_size of gate's and up's weight = 192 is not divisible by weight quantization block_n = 128
```
Fix: `enable-expert-parallel: true` — shards experts instead of the intermediate dim, so 1536 % 128 holds. This is resolved-by-config upstream (vLLM issues #30934, #31262, #17569), not a code bug.

### RedHatAI/DeepSeek-V4-Flash-NVFP4-FP8 — prerequisite fix (still blocked upstream)
`fp8_ds_mla` layout requires an fp8 KV cache; default `kv-cache-dtype=auto` asserts. Fix: `kv-cache-dtype: fp8`. Rerun [30821730862](https://github.com/neuralmagic/nm-cicd/actions/runs/30821730862) confirms the AssertionError is gone, but startup then hits a **separate upstream A100-only Triton bug** (`dynamic_func() missing ... 'launch_pdl'`, fixed on vLLM `main` in commit 823eaf667 / PR #48086, not yet released) — tracked via JIRA. Keeping this config so the model is ready once that lands. (Also dropped the redundant `tensor-parallel-size`, which the harness overrides from the profile.)

## Test
- Qwen3.6-35B-A3B smoke: **pass** (30821728603)
- DeepSeek-V4-Flash-NVFP4-FP8: config applied, first blocker cleared; blocked on upstream launch_pdl (A100-only)
- Qwen3-VL-235B FP8 ×2: config added; pending 8×H100 smoke rerun

🤖 Generated with [Claude Code](https://claude.com/claude-code)