### PR TITLE
Add Qwen3-Omni-30B-A3B-Instruct stage-overrides (thinker TP=2 on h100_quad)

### DIFF
--- a/Qwen/Qwen3-Omni-30B-A3B-Instruct/performance/server.yml
+++ b/Qwen/Qwen3-Omni-30B-A3B-Instruct/performance/server.yml
@@ -1,0 +1,19 @@
+# Qwen3-Omni full pipeline (thinker / talker / code2wav) on 3 GPUs.
+#
+# Do NOT set a global tensor-parallel-size here. Omni applies TP per stage;
+# global TP>1 with the default 1-GPU-per-stage map fails with:
+#   local_world_size (N) must be <= number of visible devices (1)
+#
+# Per-stage layout lives in stage-overrides.json (pass as --stage-overrides):
+#   stage 0 (thinker): TP=2 on devices 0,1
+#   stage 1 (talker):  TP=1 on device 2
+#   stage 2 (code2wav): TP=1 on device 2
+#
+# Registry / deploy must request gpu_count=3 (not a100_duo TP=2).
+# Serve example:
+#   vllm serve Qwen/Qwen3-Omni-30B-A3B-Instruct --omni \
+#     --stage-overrides "$(cat stage-overrides.json)"
+max-model-len: 8192
+trust-remote-code: true
+uvicorn-log-level: debug
+no-enable-prefix-caching: true

--- a/Qwen/Qwen3-Omni-30B-A3B-Instruct/performance/server.yml
+++ b/Qwen/Qwen3-Omni-30B-A3B-Instruct/performance/server.yml
@@ -1,4 +1,4 @@
-# Qwen3-Omni full pipeline (thinker / talker / code2wav) on 3 GPUs.
+# Qwen3-Omni full pipeline (thinker / talker / code2wav).
 #
 # Do NOT set a global tensor-parallel-size here. Omni applies TP per stage;
 # global TP>1 with the default 1-GPU-per-stage map fails with:
@@ -9,7 +9,9 @@
 #   stage 1 (talker):  TP=1 on device 2
 #   stage 2 (code2wav): TP=1 on device 2
 #
-# Registry / deploy must request gpu_count=3 (not a100_duo TP=2).
+# Registry allocates 4 GPUs via h100_quad (tensor_parallel_size=4 is the
+# GPU request count for Omni; there is no 3-GPU profile). Stage layout uses
+# devices 0,1,2; GPU 3 stays idle.
 # Serve example:
 #   vllm serve Qwen/Qwen3-Omni-30B-A3B-Instruct --omni \
 #     --stage-overrides "$(cat stage-overrides.json)"

--- a/Qwen/Qwen3-Omni-30B-A3B-Instruct/performance/stage-overrides.json
+++ b/Qwen/Qwen3-Omni-30B-A3B-Instruct/performance/stage-overrides.json
@@ -1,0 +1,5 @@
+{
+  "0": {"tensor_parallel_size": 2, "devices": "0,1"},
+  "1": {"devices": "2"},
+  "2": {"devices": "2"}
+}


### PR DESCRIPTION
## Summary
- Adds `Qwen/Qwen3-Omni-30B-A3B-Instruct/performance/server.yml` (engine args; **no** global `tensor-parallel-size`).
- Adds `performance/stage-overrides.json` for the Omni layout:

```json
{
  "0": {"tensor_parallel_size": 2, "devices": "0,1"},
  "1": {"devices": "2"},
  "2": {"devices": "2"}
}
```

- Intended serve shape:
  `vllm serve ... --omni --stage-overrides "$(cat .../stage-overrides.json)"`
- Smoke should allocate **4 GPUs via `h100_quad`** (`tensor_parallel_size` = GPU request count for Omni). Stage map uses devices 0,1,2; GPU 3 stays idle (no 3-GPU registry profile).

## Test plan
- [ ] nm-cicd mounts `stage-overrides.json` and passes `--stage-overrides "$(cat ...)"` for Omni
- [ ] Point this model at `h100_quad`
- [ ] Rerun Qwen3-Omni smoke and confirm `/health` comes up without the local_world_size assert