### PR TITLE
INFERENG-8300: Fix Qwen3.6-FP8 server-rocm.yml — full config with enforce-eager

### DIFF
--- a/RedHatAI/Qwen3.6-35B-A3B-FP8-dynamic/accuracy/server-rocm.yml
+++ b/RedHatAI/Qwen3.6-35B-A3B-FP8-dynamic/accuracy/server-rocm.yml
@@ -1,1 +1,10 @@
+enable-chunked-prefill: true
+max-model-len: 8192
+tensor-parallel-size: 1
+trust-remote-code: true
+enable-auto-tool-choice: true
+reasoning-parser: deepseek_r1
+tool-call-parser: qwen3_coder
+uvicorn-log-level: debug
+no-enable-prefix-caching: true
 enforce-eager: true

--- a/RedHatAI/Qwen3.6-35B-A3B-FP8-dynamic/performance/server-rocm.yml
+++ b/RedHatAI/Qwen3.6-35B-A3B-FP8-dynamic/performance/server-rocm.yml
@@ -1,1 +1,10 @@
+enable-chunked-prefill: true
+max-model-len: 8192
+tensor-parallel-size: 1
+trust-remote-code: true
+enable-auto-tool-choice: true
+reasoning-parser: deepseek_r1
+tool-call-parser: qwen3_coder
+uvicorn-log-level: debug
+no-enable-prefix-caching: true
 enforce-eager: true


### PR DESCRIPTION
## Summary

FP8 + aiter streaming produces empty visible content on ROCm — adding enforce-eager: true 
alongside the full server config since server-rocm.yml replaces server.yml entirely.

Fixed both `performance/server-rocm.yml` and `accuracy/server-rocm.yml`.

## Validation
- OCP smoke test: [31204321899](https://github.com/neuralmagic/nm-cicd/actions/runs/31204321899) — RedHatAI/Qwen3.6-35B-A3B-FP8-dynamic