### PR TITLE
Add chat-template for fdtn-ai/Foundation-Sec-8B

### DIFF
--- a/fdtn-ai/Foundation-Sec-8B/performance/server.yml
+++ b/fdtn-ai/Foundation-Sec-8B/performance/server.yml
@@ -1,0 +1,12 @@
+# https://huggingface.co/fdtn-ai/Foundation-Sec-8B
+# Base model derived from Llama-3.1-8B (LlamaForCausalLM). Its tokenizer ships
+# no chat_template, so /v1/chat/completions fails with ChatTemplateResolutionError
+# ("default chat template is no longer allowed") unless one is supplied.
+# Provide the Llama 3.1 template from the vLLM container image.
+# Note: this chat-template path resolves inside the vLLM container image only.
+max-model-len: 8192
+tensor-parallel-size: 1
+trust-remote-code: true
+uvicorn-log-level: debug
+no-enable-prefix-caching: true
+chat-template: /opt/app-root/template/tool_chat_template_llama3.1_json.jinja


### PR DESCRIPTION
## SUMMARY

`fdtn-ai/Foundation-Sec-8B` is a Llama-3.1-8B base model (`LlamaForCausalLM`, llama3.1 rope scaling) whose tokenizer ships **no `chat_template`**. On the OCP image smoke test, `/v1/completions` passes but `/v1/chat/completions` fails:

```
vllm.entrypoints.chat_utils.ChatTemplateResolutionError:
As of transformers v4.44, default chat template is no longer allowed, so you must
provide a chat template if the tokenizer does not define one.
```
(run [31243347074](https://github.com/neuralmagic/nm-cicd/actions/runs/31243347074), `test_smoke_chat_completion[base]` → 400).

The model serves fine; this is a config gap, not a vLLM bug.

This PR adds `fdtn-ai/Foundation-Sec-8B/performance/server.yml` supplying the Llama 3.1 chat template shipped in the vLLM container image. The OCP smoke test loads this file as `guidellm_server`, so the `[base]` chat variant now has a template. Mirrors the existing pattern in `meta-llama/Llama-3.1-8B-Instruct/performance/server.yml`.

## TEST PLAN

Retriggered `ocp-test.yml` smoke test for `fdtn-ai/Foundation-Sec-8B` with `config_ref=add-foundation-sec-8b-chat-template` (link to follow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)