### PR TITLE
Add CPU server config for Qwen2.5-VL-7B-Instruct

### DIFF
--- a/Qwen/Qwen2.5-VL-7B-Instruct/performance/server-cpu.yml
+++ b/Qwen/Qwen2.5-VL-7B-Instruct/performance/server-cpu.yml
@@ -1,0 +1,7 @@
+# CPU-specific config: VL models need higher max-model-len for image tokens
+max-model-len: 8192
+tensor-parallel-size: 1
+trust-remote-code: true
+uvicorn-log-level: debug
+no-enable-prefix-caching: true
+block-size: 128


### PR DESCRIPTION
The default CPU max-model-len (2048) is too small for VL models with image tokens (input was 5487 tokens). Adds a CPU-specific server config with max-model-len 8192.

Fixes CPU smoke test failure for Qwen/Qwen2.5-VL-7B-Instruct in OCP model validation.