### PR TITLE
Fix Qwen3.6-35B-A3B reasoning-parser: qwen3, not deepseek_r1

### DIFF
--- a/Qwen/Qwen3.6-35B-A3B/performance/server.yml
+++ b/Qwen/Qwen3.6-35B-A3B/performance/server.yml
@@ -3,7 +3,7 @@ max-model-len: 8192
 tensor-parallel-size: 1
 trust-remote-code: true
 enable-auto-tool-choice: true
-reasoning-parser: deepseek_r1
+reasoning-parser: qwen3
 tool-call-parser: qwen3_coder
 uvicorn-log-level: debug
 no-enable-prefix-caching: true

--- a/RedHatAI/Qwen3.6-35B-A3B-FP8-dynamic/accuracy/server-rocm.yml
+++ b/RedHatAI/Qwen3.6-35B-A3B-FP8-dynamic/accuracy/server-rocm.yml
@@ -3,7 +3,7 @@ max-model-len: 8192
 tensor-parallel-size: 1
 trust-remote-code: true
 enable-auto-tool-choice: true
-reasoning-parser: deepseek_r1
+reasoning-parser: qwen3
 tool-call-parser: qwen3_coder
 uvicorn-log-level: debug
 no-enable-prefix-caching: true

--- a/RedHatAI/Qwen3.6-35B-A3B-FP8-dynamic/performance/server-rocm.yml
+++ b/RedHatAI/Qwen3.6-35B-A3B-FP8-dynamic/performance/server-rocm.yml
@@ -3,7 +3,7 @@ max-model-len: 8192
 tensor-parallel-size: 1
 trust-remote-code: true
 enable-auto-tool-choice: true
-reasoning-parser: deepseek_r1
+reasoning-parser: qwen3
 tool-call-parser: qwen3_coder
 uvicorn-log-level: debug
 no-enable-prefix-caching: true

--- a/RedHatAI/Qwen3.6-35B-A3B-FP8-dynamic/performance/server.yml
+++ b/RedHatAI/Qwen3.6-35B-A3B-FP8-dynamic/performance/server.yml
@@ -3,7 +3,7 @@ max-model-len: 8192
 tensor-parallel-size: 1
 trust-remote-code: true
 enable-auto-tool-choice: true
-reasoning-parser: deepseek_r1
+reasoning-parser: qwen3
 tool-call-parser: qwen3_coder
 uvicorn-log-level: debug
 no-enable-prefix-caching: true


### PR DESCRIPTION
SUMMARY:
`Qwen/Qwen3.6-35B-A3B` and its `RedHatAI/Qwen3.6-35B-A3B-FP8-dynamic` quantized sibling set `reasoning-parser: deepseek_r1` in their server configs — a likely copy-paste leftover, since `tool-call-parser: qwen3_coder` was already set correctly. The upstream vLLM recipe for this model (via [vllm-project/recipes](https://github.com/vllm-project/recipes)) recommends `reasoning-parser: qwen3`. Fixed all 4 files carrying the wrong value:

- `Qwen/Qwen3.6-35B-A3B/performance/server.yml`
- `RedHatAI/Qwen3.6-35B-A3B-FP8-dynamic/performance/server.yml`
- `RedHatAI/Qwen3.6-35B-A3B-FP8-dynamic/performance/server-rocm.yml`
- `RedHatAI/Qwen3.6-35B-A3B-FP8-dynamic/accuracy/server-rocm.yml`

`Qwen/Qwen3.6-35B-A3B` is tagged `3.5-ga` in `model_registry.yml` with `test_types: [lm_eval, guidellm]` and `image_test_types: [smoke, tool_calling, benchmarks]`, so the wrong parser is live in both accuracy eval and tool-calling tests for the current GA release. This may also be a contributing factor to INFERENG-9506 (malformed tool calls on the FP8-dynamic variant), since a wrong reasoning parser can corrupt how reasoning/tool-call segments are split out of the model's output.

Found via a new comparison tool (`nm-cicd/.github/scripts/compare_configs_to_recipes.py`) that diffs our `server.yml` configs against upstream `vllm-project/recipes` guidance.

TEST PLAN:
- [ ] Re-run accuracy (`lm_eval`) validation for `Qwen/Qwen3.6-35B-A3B` and confirm reasoning-token extraction works correctly with `reasoning-parser: qwen3`
- [ ] Re-run tool-calling image test for both `Qwen/Qwen3.6-35B-A3B` and `RedHatAI/Qwen3.6-35B-A3B-FP8-dynamic`
- [ ] Optionally cross-check whether this fix resolves or improves INFERENG-9506