### PR TITLE
[DEMO, do not merge] Validate #107's recipes-check on a real PR

### DIFF
--- a/Qwen/Qwen3.6-35B-A3B/performance/server.yml
+++ b/Qwen/Qwen3.6-35B-A3B/performance/server.yml
@@ -3,8 +3,8 @@ max-model-len: 8192
 tensor-parallel-size: 1
 trust-remote-code: true
 enable-auto-tool-choice: true
-reasoning-parser: deepseek_r1
-tool-call-parser: hermes
+reasoning-parser: qwen3
+tool-call-parser: qwen3_coder
 uvicorn-log-level: debug
 no-enable-prefix-caching: true
 # Hybrid Mamba MoE: each decode sequence needs one Mamba cache block.

--- a/Qwen/Qwen3.6-35B-A3B/performance/server.yml
+++ b/Qwen/Qwen3.6-35B-A3B/performance/server.yml
@@ -4,7 +4,7 @@ tensor-parallel-size: 1
 trust-remote-code: true
 enable-auto-tool-choice: true
 reasoning-parser: deepseek_r1
-tool-call-parser: qwen3_coder
+tool-call-parser: hermes
 uvicorn-log-level: debug
 no-enable-prefix-caching: true
 # Hybrid Mamba MoE: each decode sequence needs one Mamba cache block.


### PR DESCRIPTION
Throwaway PR to validate that #107's `recipes-check` workflow actually fires on a real `pull_request` event (its own PR doesn't touch a `server.yml`, so the path filter never triggers there).

Deliberately touches `Qwen/Qwen3.6-35B-A3B/performance/server.yml` to exercise all three finding tiers the check produces:
- `reasoning-parser: deepseek_r1` (pre-existing on this branch, predates #104's fix) — high-confidence correctness diff
- `tool-call-parser: hermes` (deliberately wrong) — advisory-tier diff
- `mm-encoder-tp-mode` left unset — generic missing_local note

Will push a follow-up commit reverting both once the check's output is confirmed, then close without merging (base branch `ci/recipes-check` still has the stale pre-#104 reasoning-parser value, so this must never land).

Local dry run confirms all three findings render correctly; this PR exists to confirm the same on GitHub Actions infra + the PR-comment step.