### PR TITLE
[DEMO, do not merge] Evidence: tool-call-parser top-tier + recipe links

### DIFF
--- a/Qwen/Qwen3.6-35B-A3B/performance/server.yml
+++ b/Qwen/Qwen3.6-35B-A3B/performance/server.yml
@@ -3,8 +3,8 @@ max-model-len: 8192
 tensor-parallel-size: 1
 trust-remote-code: true
 enable-auto-tool-choice: true
-reasoning-parser: qwen3
-tool-call-parser: qwen3_coder
+reasoning-parser: deepseek_r1
+tool-call-parser: hermes
 uvicorn-log-level: debug
 no-enable-prefix-caching: true
 # Hybrid Mamba MoE: each decode sequence needs one Mamba cache block.

--- a/Qwen/Qwen3.6-35B-A3B/performance/server.yml
+++ b/Qwen/Qwen3.6-35B-A3B/performance/server.yml
@@ -3,7 +3,7 @@ max-model-len: 8192
 tensor-parallel-size: 1
 trust-remote-code: true
 enable-auto-tool-choice: true
-reasoning-parser: qwen3
+reasoning-parser: deepseek_r1
 tool-call-parser: qwen3_coder
 uvicorn-log-level: debug
 no-enable-prefix-caching: true

--- a/Qwen/Qwen3.6-35B-A3B/performance/server.yml
+++ b/Qwen/Qwen3.6-35B-A3B/performance/server.yml
@@ -3,8 +3,8 @@ max-model-len: 8192
 tensor-parallel-size: 1
 trust-remote-code: true
 enable-auto-tool-choice: true
-reasoning-parser: deepseek_r1
-tool-call-parser: hermes
+reasoning-parser: qwen3
+tool-call-parser: qwen3_coder
 uvicorn-log-level: debug
 no-enable-prefix-caching: true
 # Hybrid Mamba MoE: each decode sequence needs one Mamba cache block.

--- a/Qwen/Qwen3.6-35B-A3B/performance/server.yml
+++ b/Qwen/Qwen3.6-35B-A3B/performance/server.yml
@@ -10,3 +10,4 @@ no-enable-prefix-caching: true
 # Hybrid Mamba MoE: each decode sequence needs one Mamba cache block.
 max-num-seqs: 64
 gpu-memory-utilization: 0.95
+# recipes-check demo evidence marker (PR #109) -- values above are correct

--- a/Qwen/Qwen3.6-35B-A3B/performance/server.yml
+++ b/Qwen/Qwen3.6-35B-A3B/performance/server.yml
@@ -3,11 +3,12 @@ max-model-len: 8192
 tensor-parallel-size: 1
 trust-remote-code: true
 enable-auto-tool-choice: true
-reasoning-parser: deepseek_r1
+reasoning-parser: qwen3
 tool-call-parser: qwen3_coder
 uvicorn-log-level: debug
 no-enable-prefix-caching: true
 # Hybrid Mamba MoE: each decode sequence needs one Mamba cache block.
 max-num-seqs: 64
 gpu-memory-utilization: 0.95
-# recipes-check demo evidence marker (PR #109) -- values above are correct
+# recipes-check demo evidence marker (PR #109) -- final state: values correct,
+# --fail-on correctness tested to both fail (bug reintroduced) and pass (this)


### PR DESCRIPTION
Throwaway PR to capture real GitHub Actions evidence for two changes just added to #107:
1. `tool-call-parser` conflicts now render top-tier ("Worth a look"), same as `reasoning-parser`.
2. Findings link to the actual recipe page as evidence.

Deliberately reintroduces both `reasoning-parser: deepseek_r1` and `tool-call-parser: hermes` on `Qwen/Qwen3.6-35B-A3B/performance/server.yml` (both wrong, both should render top-tier with a working `recipes.vllm.ai` link).

Will push a follow-up commit reverting both once the check's output is confirmed, then close without merging (base branch `ci/recipes-check` predates the real fix, so this must never land).